### PR TITLE
Fixing main page's link to plugins

### DIFF
--- a/_layouts/about.html.slim
+++ b/_layouts/about.html.slim
@@ -7,7 +7,7 @@ layout: base
     img src="images/logo-white.png"
     p.lead A powerful plugin framework for converting your functions into composable, discoverable, production-ready services with minimal overhead.
     .col-md-3.col-md-offset-3
-      a.btn.btn-default.btn-lg.btn-nowrap role="button" href="/docs/plugin-developer-guide/"
+      a.btn.btn-default.btn-lg.btn-nowrap role="button" href="/docs/plugins/plugin-developer-guide/"
         span.pull-left
           i.fa.fa-pencil   Start Writing Plugins!
     .col-md-3


### PR DESCRIPTION
The main "Start Writing Plugins" button doesn't work. This fixes that.