### PR TITLE
General updates to bring more things in line with v3

### DIFF
--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -72,7 +72,7 @@ body.antialiased
       a.gitter href="https://gitter.im/beer-garden-io/Lobby"
         i.fa.fa-gitter
     .footer-copyright
-      p © Beer Garden Project 2018.
+      p © Beer Garden Project 2022.
 
     include footer.html.slim
 

--- a/docs/app/api-users-guide.adoc
+++ b/docs/app/api-users-guide.adoc
@@ -8,7 +8,7 @@ This guide is intended for people who would like to use Beer Garden's API. Basic
 NOTE: If you feel like you know REST pretty well, Beer Garden comes with OpenAPI (formerly known as Swagger) documentation that helps you explore the REST API yourself. You can find a SwaggerUI page linked from the About page of any Beer Garden web UI.
 
 TIP: This guide assumes you're at least somewhat aware of how Beer Garden is organized. If you need a refresher you should check out
-link:../what-is-beergarden/[what is Beer Garden?]
+link:/docs/startup/what-is-beergarden/[what is Beer Garden?]
 
 
 == Client Libraries

--- a/docs/app/config_yaml.adoc
+++ b/docs/app/config_yaml.adoc
@@ -1,4 +1,5 @@
 = Beer Garden Configuration
+:page-layout: docs
 
 This document describes the configuration for Beer Garden. Each section will
 document a particular configuration value and its description. First,
@@ -18,55 +19,60 @@ This section outlines the various configuration items Beer Garden supports.
 |===
 | Name | Type | Default | Description
 
-| <<application.cors_enabled,application.cors_enabled>>
+| <<auth.authentication_handlers.basic.enabled,auth.authentication_handlers.basic.enabled>>
+| bool
+| True
+| Enable authentication via username andpassword
+
+| <<auth.authentication_handlers.trusted_header.create_users,auth.authentication_handlers.trusted_header.create_users>>
+| bool
+| True
+| Create an account for the user specified byusername_header if one does not already exist
+
+| <<auth.authentication_handlers.trusted_header.enabled,auth.authentication_handlers.trusted_header.enabled>>
 | bool
 | False
-| Determine if CORS should be enabled
+| Enable authentication via trusted headers
 
-| <<application.debug_mode,application.debug_mode>>
-| bool
-| False
-| Run the application in debug mode
-
-| <<application.execute_javascript,application.execute_javascript>>
-| bool
-| False
-| Execute plugin-provided javascript
-
-| <<application.icon_default,application.icon_default>>
+| <<auth.authentication_handlers.trusted_header.user_groups_header,auth.authentication_handlers.trusted_header.user_groups_header>>
 | str
-| fa-beer
-| Default font-awesome icon to display
+| bg-user-groups
+| The http header containing the comma separated list of the user's groups.
 
-| <<application.name,application.name>>
+| <<auth.authentication_handlers.trusted_header.username_header,auth.authentication_handlers.trusted_header.username_header>>
 | str
-| Beer Garden
-| The title to display on the GUI
+| bg-username
+| The http header containing the username
+
+| <<auth.default_admin.password,auth.default_admin.password>>
+| str
+| password
+| The password for the default admin account that will be created when initializing a new environment
+
+| <<auth.default_admin.username,auth.default_admin.username>>
+| str
+| admin
+| The username for the default admin account that will be created when initializing a new environment
 
 | <<auth.enabled,auth.enabled>>
 | bool
 | False
 | Use role-based authentication / authorization
 
-| <<auth.guest_login_enabled,auth.guest_login_enabled>>
-| bool
-| True
-| Only applicable if auth is enabled. If set to true, guests can login without username/passwords.
-
-| <<auth.token.algorithm,auth.token.algorithm>>
+| <<auth.group_definition_file,auth.group_definition_file>>
 | str
-| HS256
-| Algorithm to use when signing tokens
+| None
+| Path to the file containg a mapping of groups to beer garden role assignments
 
-| <<auth.token.lifetime,auth.token.lifetime>>
-| int
-| 1200
-| Time (seconds) before a token expires
+| <<auth.role_definition_file,auth.role_definition_file>>
+| str
+| None
+| Path to the yaml file that defines roles used for authorization
 
-| <<auth.token.secret,auth.token.secret>>
+| <<auth.token_secret,auth.token_secret>>
 | str
 |
-| Secret to use when signing tokens
+| Secret to use when signing authentication tokens
 
 | <<configuration.file,configuration.file>>
 | str
@@ -103,6 +109,11 @@ This section outlines the various configuration items Beer Garden supports.
 | -1
 | Number of minutes to wait before deleting ACTION requests (negative number for never)
 
+| <<db.ttl.file,db.ttl.file>>
+| int
+| 15
+| Number of minutes to wait before deleting FILE documents (negative number for never)
+
 | <<db.ttl.info,db.ttl.info>>
 | int
 | 15
@@ -122,11 +133,6 @@ This section outlines the various configuration items Beer Garden supports.
 | int
 | 2337
 | Serve content on this port
-
-| <<entry.http.public_fqdn,entry.http.public_fqdn>>
-| str
-| localhost
-| Public fully-qualified domain name
 
 | <<entry.http.ssl.ca_cert,entry.http.ssl.ca_cert>>
 | str
@@ -162,6 +168,66 @@ This section outlines the various configuration items Beer Garden supports.
 | str
 | /
 | URL path prefix
+
+| <<entry.stomp.enabled,entry.stomp.enabled>>
+| bool
+| False
+| Connect to a Stomp Broker
+
+| <<entry.stomp.headers,entry.stomp.headers>>
+| list
+| []
+| Headers to be sent with messages. Follows standard YAML formatting for lists with two variables 'key' and 'value'
+
+| <<entry.stomp.host,entry.stomp.host>>
+| str
+| localhost
+| Broker hostname
+
+| <<entry.stomp.password,entry.stomp.password>>
+| str
+| None
+| Password to use for authentication
+
+| <<entry.stomp.port,entry.stomp.port>>
+| int
+| 61613
+| Broker port
+
+| <<entry.stomp.send_destination,entry.stomp.send_destination>>
+| str
+| None
+| Topic where events are published
+
+| <<entry.stomp.ssl.ca_cert,entry.stomp.ssl.ca_cert>>
+| str
+| None
+| Path to certificate file containing the certificate of the authority that issued the message broker certificate
+
+| <<entry.stomp.ssl.client_cert,entry.stomp.ssl.client_cert>>
+| str
+| None
+| Path to client public certificate to use when communicating with the message broker
+
+| <<entry.stomp.ssl.client_key,entry.stomp.ssl.client_key>>
+| str
+| None
+| Path to client private key to use when communicating with the message broker
+
+| <<entry.stomp.ssl.use_ssl,entry.stomp.ssl.use_ssl>>
+| bool
+| False
+| Use SSL when connecting to the message broker
+
+| <<entry.stomp.subscribe_destination,entry.stomp.subscribe_destination>>
+| str
+| None
+| Topic to listen for operations
+
+| <<entry.stomp.username,entry.stomp.username>>
+| str
+| None
+| Username to use for authentication
 
 | <<garden.name,garden.name>>
 | str
@@ -301,12 +367,27 @@ This section outlines the various configuration items Beer Garden supports.
 | <<mq.host,mq.host>>
 | str
 | localhost
-| Hostname of MQ to use
+| Will be used by the Beergarden application as the location of the message broker.
 
 | <<mq.virtual_host,mq.virtual_host>>
 | str
 | /
 | Virtual host to use for MQ
+
+| <<parent.http.access_token,parent.http.access_token>>
+| str
+| None
+| Access token for authentication
+
+| <<parent.http.api_version,parent.http.api_version>>
+| int
+| 1
+| Beergarden API version
+
+| <<parent.http.client_timeout,parent.http.client_timeout>>
+| float
+| -1
+| Max time RestClient will wait for server response
 
 | <<parent.http.enabled,parent.http.enabled>>
 | bool
@@ -315,58 +396,128 @@ This section outlines the various configuration items Beer Garden supports.
 
 | <<parent.http.host,parent.http.host>>
 | str
-| 0.0.0.0
+| None
 | Host for the HTTP Server to bind to
+
+| <<parent.http.password,parent.http.password>>
+| str
+| None
+| Password for authentication
 
 | <<parent.http.port,parent.http.port>>
 | int
 | 2337
 | Serve content on this port
 
-| <<parent.http.public_fqdn,parent.http.public_fqdn>>
+| <<parent.http.refresh_token,parent.http.refresh_token>>
 | str
-| localhost
-| Public fully-qualified domain name
-
-| <<parent.http.skip_events,parent.http.skip_events>>
-| list
-| ['DB_CREATE']
-| Events to be skipped
+| None
+| Refresh token for authentication
 
 | <<parent.http.ssl.ca_cert,parent.http.ssl.ca_cert>>
 | str
 | None
 | Path to CA certificate file to use for SSLContext
 
-| <<parent.http.ssl.ca_path,parent.http.ssl.ca_path>>
+| <<parent.http.ssl.ca_verify,parent.http.ssl.ca_verify>>
+| bool
+| True
+| Verify server certificate when using SSL
+
+| <<parent.http.ssl.client_cert,parent.http.ssl.client_cert>>
 | str
 | None
-| Path to CA certificate path to use for SSLContext
+| Client certificate to use
 
-| <<parent.http.ssl.client_cert_verify,parent.http.ssl.client_cert_verify>>
+| <<parent.http.ssl.client_key,parent.http.ssl.client_key>>
 | str
-| NONE
-| Client certificate mode to use when handling requests
+| None
+| Client key to use
 
 | <<parent.http.ssl.enabled,parent.http.ssl.enabled>>
 | bool
 | False
-| Serve content using SSL
-
-| <<parent.http.ssl.private_key,parent.http.ssl.private_key>>
-| str
-| None
-| Path to a private key
-
-| <<parent.http.ssl.public_key,parent.http.ssl.public_key>>
-| str
-| None
-| Path to a public key
+| Use SSL when connecting
 
 | <<parent.http.url_prefix,parent.http.url_prefix>>
 | str
 | /
 | URL path prefix
+
+| <<parent.http.username,parent.http.username>>
+| str
+| None
+| Username for authentication
+
+| <<parent.skip_events,parent.skip_events>>
+| list
+| []
+| Events to be skipped
+
+| <<parent.stomp.enabled,parent.stomp.enabled>>
+| bool
+| False
+| Publish events to parent garden over STOMP
+
+| <<parent.stomp.headers,parent.stomp.headers>>
+| list
+| []
+| Headers to be sent with messages. Follows standard YAML formatting for lists with two variables 'key' and 'value'
+
+| <<parent.stomp.host,parent.stomp.host>>
+| str
+| localhost
+| Broker hostname
+
+| <<parent.stomp.password,parent.stomp.password>>
+| str
+| None
+| Password to use for authentication
+
+| <<parent.stomp.port,parent.stomp.port>>
+| int
+| 61613
+| Broker port
+
+| <<parent.stomp.send_destination,parent.stomp.send_destination>>
+| str
+| None
+| Topic where events are published
+
+| <<parent.stomp.ssl.ca_cert,parent.stomp.ssl.ca_cert>>
+| str
+| None
+| Path to certificate file containing the certificate of the authority that issued the message broker certificate
+
+| <<parent.stomp.ssl.client_cert,parent.stomp.ssl.client_cert>>
+| str
+| None
+| Path to client public certificate to use when communicating with the message broker
+
+| <<parent.stomp.ssl.client_key,parent.stomp.ssl.client_key>>
+| str
+| None
+| Path to client private key to use when communicating with the message broker
+
+| <<parent.stomp.ssl.use_ssl,parent.stomp.ssl.use_ssl>>
+| bool
+| False
+| Use SSL when connecting to message broker
+
+| <<parent.stomp.subscribe_destination,parent.stomp.subscribe_destination>>
+| str
+| None
+| Topic to listen for operations
+
+| <<parent.stomp.username,parent.stomp.username>>
+| str
+| None
+| Username to use for authentication
+
+| <<plugin.allow_command_updates,plugin.allow_command_updates>>
+| bool
+| False
+| Allow commands of non-dev systems to be updated
 
 | <<plugin.local.auth.password,plugin.local.auth.password>>
 | str
@@ -388,10 +539,15 @@ This section outlines the various configuration items Beer Garden supports.
 | []
 | Host environment variables that will be propagated to local plugin processes
 
-| <<plugin.local.logging.stream_files,plugin.local.logging.stream_files>>
-| bool
-| False
-| Write plugin STDOUT to plugin.out and plugin STDERR to plugin.err
+| <<plugin.local.logging.config_file,plugin.local.logging.config_file>>
+| str
+| None
+| Path to a logging configuration file for local plugins
+
+| <<plugin.local.logging.fallback_level,plugin.local.logging.fallback_level>>
+| str
+| INFO
+| Level that will be used with a default logging configuration if config_file is not specified
 
 | <<plugin.local.timeout.shutdown,plugin.local.timeout.shutdown>>
 | int
@@ -403,12 +559,17 @@ This section outlines the various configuration items Beer Garden supports.
 | 5
 | Seconds to wait for a plugin to start
 
-| <<plugin.logging.config_file,plugin.logging.config_file>>
+| <<plugin.mq.host,plugin.mq.host>>
+| str
+| localhost
+| Globally resolvable host name of message broker
+
+| <<plugin.remote.logging.config_file,plugin.remote.logging.config_file>>
 | str
 | None
 | Path to a logging configuration file for plugins
 
-| <<plugin.logging.fallback_level,plugin.logging.fallback_level>>
+| <<plugin.remote.logging.fallback_level,plugin.remote.logging.fallback_level>>
 | str
 | INFO
 | Level that will be used with a default logging configuration if config_file is not specified
@@ -423,20 +584,20 @@ This section outlines the various configuration items Beer Garden supports.
 | 30
 | Amount of time to wait before marking a plugin asunresponsive
 
-| <<publish_hostname,publish_hostname>>
-| str
-| localhost
-| Publicly accessible hostname for plugins to connect to
+| <<request_validation.dynamic_choices.command.timeout,request_validation.dynamic_choices.command.timeout>>
+| int
+| 10
+| Time to wait for a command-based choices validation
 
-| <<scheduler.auth.password,scheduler.auth.password>>
+| <<request_validation.dynamic_choices.url.ca_cert,request_validation.dynamic_choices.url.ca_cert>>
 | str
 | None
-| Password that scheduler will use for authentication (needs bg-admin role)
+| CA file for validating url-based choices
 
-| <<scheduler.auth.username,scheduler.auth.username>>
-| str
-| None
-| Username that scheduler will use for authentication (needs bg-admin role)
+| <<request_validation.dynamic_choices.url.ca_verify,request_validation.dynamic_choices.url.ca_verify>>
+| bool
+| True
+| Verify external certificates for url-based choices
 
 | <<scheduler.job_defaults.coalesce,scheduler.job_defaults.coalesce>>
 | bool
@@ -453,25 +614,105 @@ This section outlines the various configuration items Beer Garden supports.
 | 10
 | Number of workers (processes) to run concurrently.
 
-| <<validator.command.timeout,validator.command.timeout>>
-| int
-| 10
-| Time to wait for a command-based choices validation
-
-| <<validator.url.ca_cert,validator.url.ca_cert>>
-| str
-| None
-| CA file for validating url-based choices
-
-| <<validator.url.ca_verify,validator.url.ca_verify>>
+| <<ui.cors_enabled,ui.cors_enabled>>
 | bool
-| True
-| Verify external certificates for url-based choices
+| False
+| Determine if CORS should be enabled
+
+| <<ui.debug_mode,ui.debug_mode>>
+| bool
+| False
+| Run the application in debug mode
+
+| <<ui.execute_javascript,ui.execute_javascript>>
+| bool
+| False
+| Execute plugin-provided javascript
+
+| <<ui.icon_default,ui.icon_default>>
+| str
+| fa-beer
+| Default font-awesome icon to display
+
+| <<ui.name,ui.name>>
+| str
+| Beer Garden
+| The title to display on the GUI
 |===
 
-=== application.cors_enabled
+=== auth.authentication_handlers.basic.enabled
 
-Determine if CORS should be enabled
+Enable authentication via username andpassword
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `True`
+
+| *env_name*
+| `BG_AUTH_AUTHENTICATION_HANDLERS_BASIC_ENABLED`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--auth-authentication_handlers-basic-no-enabled`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set auth.authentication_handlers.basic.enabled from the environment by setting the environment variable `BG_AUTH_AUTHENTICATION_HANDLERS_BASIC_ENABLED`
+
+You can set `auth.authentication_handlers.basic.enabled` from the command-line by specifying `--auth-authentication_handlers-basic-no-enabled` at Beer Garden's entrypoint.
+
+If `auth.authentication_handlers.basic.enabled` is not set in any of the sources listed, it will fallback to the default value `True`
+
+=== auth.authentication_handlers.trusted_header.create_users
+
+Create an account for the user specified byusername_header if one does not already exist
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `True`
+
+| *env_name*
+| `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_CREATE_USERS`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--auth-authentication_handlers-trusted_header-no-create-users`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set auth.authentication_handlers.trusted_header.create_users from the environment by setting the environment variable `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_CREATE_USERS`
+
+You can set `auth.authentication_handlers.trusted_header.create_users` from the command-line by specifying `--auth-authentication_handlers-trusted_header-no-create-users` at Beer Garden's entrypoint.
+
+If `auth.authentication_handlers.trusted_header.create_users` is not set in any of the sources listed, it will fallback to the default value `True`
+
+=== auth.authentication_handlers.trusted_header.enabled
+
+Enable authentication via trusted headers
 
 |===
 | Attribute | Value
@@ -483,13 +724,13 @@ Determine if CORS should be enabled
 | `False`
 
 | *env_name*
-| `BG_APPLICATION_CORS_ENABLED`
+| `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_ENABLED`
 
 | *required*
 | `True`
 
 | *cli_name*
-| `--application-cors-enabled`
+| `--auth-authentication_handlers-trusted_header-enabled`
 
 | *fallback*
 | `None`
@@ -498,81 +739,13 @@ Determine if CORS should be enabled
 | `None`
 |===
 
-You can set application.cors_enabled from the environment by setting the environment variable `BG_APPLICATION_CORS_ENABLED`
+You can set auth.authentication_handlers.trusted_header.enabled from the environment by setting the environment variable `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_ENABLED`
 
-You can set `application.cors_enabled` from the command-line by specifying `--application-cors-enabled` at Beer Garden's entrypoint.
+You can set `auth.authentication_handlers.trusted_header.enabled` from the command-line by specifying `--auth-authentication_handlers-trusted_header-enabled` at Beer Garden's entrypoint.
 
-=== application.debug_mode
+=== auth.authentication_handlers.trusted_header.user_groups_header
 
-Run the application in debug mode
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `bool`
-
-| *default*
-| `False`
-
-| *env_name*
-| `BG_APPLICATION_DEBUG_MODE`
-
-| *required*
-| `True`
-
-| *cli_name*
-| `--application-debug-mode`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set application.debug_mode from the environment by setting the environment variable `BG_APPLICATION_DEBUG_MODE`
-
-You can set `application.debug_mode` from the command-line by specifying `--application-debug-mode` at Beer Garden's entrypoint.
-
-=== application.execute_javascript
-
-Execute plugin-provided javascript
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `bool`
-
-| *default*
-| `False`
-
-| *env_name*
-| `BG_APPLICATION_EXECUTE_JAVASCRIPT`
-
-| *required*
-| `True`
-
-| *cli_name*
-| `--application-execute-javascript`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set application.execute_javascript from the environment by setting the environment variable `BG_APPLICATION_EXECUTE_JAVASCRIPT`
-
-You can set `application.execute_javascript` from the command-line by specifying `--application-execute-javascript` at Beer Garden's entrypoint.
-
-This is dangerous!! Setting this to true will instruct the browser to execute javascript provided by plugins. This means you MUST have control over all plugins running in the environment, otherwise this is a problem waiting to happen.
-
-=== application.icon_default
-
-Default font-awesome icon to display
+The http header containing the comma separated list of the user's groups.
 
 |===
 | Attribute | Value
@@ -581,16 +754,16 @@ Default font-awesome icon to display
 | `str`
 
 | *default*
-| `fa-beer`
+| `bg-user-groups`
 
 | *env_name*
-| `BG_APPLICATION_ICON_DEFAULT`
+| `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_USER_GROUPS_HEADER`
 
 | *required*
 | `True`
 
 | *cli_name*
-| `--application-icon-default`
+| `--auth-authentication_handlers-trusted_header-user-groups-header`
 
 | *fallback*
 | `None`
@@ -599,15 +772,15 @@ Default font-awesome icon to display
 | `None`
 |===
 
-You can set application.icon_default from the environment by setting the environment variable `BG_APPLICATION_ICON_DEFAULT`
+You can set auth.authentication_handlers.trusted_header.user_groups_header from the environment by setting the environment variable `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_USER_GROUPS_HEADER`
 
-You can set `application.icon_default` from the command-line by specifying `--application-icon-default` at Beer Garden's entrypoint.
+You can set `auth.authentication_handlers.trusted_header.user_groups_header` from the command-line by specifying `--auth-authentication_handlers-trusted_header-user-groups-header` at Beer Garden's entrypoint.
 
-If `application.icon_default` is not set in any of the sources listed, it will fallback to the default value `fa-beer`
+If `auth.authentication_handlers.trusted_header.user_groups_header` is not set in any of the sources listed, it will fallback to the default value `bg-user-groups`
 
-=== application.name
+=== auth.authentication_handlers.trusted_header.username_header
 
-The title to display on the GUI
+The http header containing the username
 
 |===
 | Attribute | Value
@@ -616,16 +789,16 @@ The title to display on the GUI
 | `str`
 
 | *default*
-| `Beer Garden`
+| `bg-username`
 
 | *env_name*
-| `BG_APPLICATION_NAME`
+| `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_USERNAME_HEADER`
 
 | *required*
 | `True`
 
 | *cli_name*
-| `--application-name`
+| `--auth-authentication_handlers-trusted_header-username-header`
 
 | *fallback*
 | `None`
@@ -634,11 +807,81 @@ The title to display on the GUI
 | `None`
 |===
 
-You can set application.name from the environment by setting the environment variable `BG_APPLICATION_NAME`
+You can set auth.authentication_handlers.trusted_header.username_header from the environment by setting the environment variable `BG_AUTH_AUTHENTICATION_HANDLERS_TRUSTED_HEADER_USERNAME_HEADER`
 
-You can set `application.name` from the command-line by specifying `--application-name` at Beer Garden's entrypoint.
+You can set `auth.authentication_handlers.trusted_header.username_header` from the command-line by specifying `--auth-authentication_handlers-trusted_header-username-header` at Beer Garden's entrypoint.
 
-If `application.name` is not set in any of the sources listed, it will fallback to the default value `Beer Garden`
+If `auth.authentication_handlers.trusted_header.username_header` is not set in any of the sources listed, it will fallback to the default value `bg-username`
+
+=== auth.default_admin.password
+
+The password for the default admin account that will be created when initializing a new environment
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `password`
+
+| *env_name*
+| `BG_AUTH_DEFAULT_ADMIN_PASSWORD`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--auth-default_admin-password`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set auth.default_admin.password from the environment by setting the environment variable `BG_AUTH_DEFAULT_ADMIN_PASSWORD`
+
+You can set `auth.default_admin.password` from the command-line by specifying `--auth-default_admin-password` at Beer Garden's entrypoint.
+
+If `auth.default_admin.password` is not set in any of the sources listed, it will fallback to the default value `password`
+
+=== auth.default_admin.username
+
+The username for the default admin account that will be created when initializing a new environment
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `admin`
+
+| *env_name*
+| `BG_AUTH_DEFAULT_ADMIN_USERNAME`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--auth-default_admin-username`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set auth.default_admin.username from the environment by setting the environment variable `BG_AUTH_DEFAULT_ADMIN_USERNAME`
+
+You can set `auth.default_admin.username` from the command-line by specifying `--auth-default_admin-username` at Beer Garden's entrypoint.
+
+If `auth.default_admin.username` is not set in any of the sources listed, it will fallback to the default value `admin`
 
 === auth.enabled
 
@@ -673,44 +916,9 @@ You can set auth.enabled from the environment by setting the environment variabl
 
 You can set `auth.enabled` from the command-line by specifying `--auth-enabled` at Beer Garden's entrypoint.
 
-=== auth.guest_login_enabled
+=== auth.group_definition_file
 
-Only applicable if auth is enabled. If set to true, guests can login without username/passwords.
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `bool`
-
-| *default*
-| `True`
-
-| *env_name*
-| `BG_AUTH_GUEST_LOGIN_ENABLED`
-
-| *required*
-| `True`
-
-| *cli_name*
-| `--auth-no-guest-login-enabled`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set auth.guest_login_enabled from the environment by setting the environment variable `BG_AUTH_GUEST_LOGIN_ENABLED`
-
-You can set `auth.guest_login_enabled` from the command-line by specifying `--auth-no-guest-login-enabled` at Beer Garden's entrypoint.
-
-If `auth.guest_login_enabled` is not set in any of the sources listed, it will fallback to the default value `True`
-
-=== auth.token.algorithm
-
-Algorithm to use when signing tokens
+Path to the file containg a mapping of groups to beer garden role assignments
 
 |===
 | Attribute | Value
@@ -719,16 +927,16 @@ Algorithm to use when signing tokens
 | `str`
 
 | *default*
-| `HS256`
+| `None`
 
 | *env_name*
-| `BG_AUTH_TOKEN_ALGORITHM`
+| `BG_AUTH_GROUP_DEFINITION_FILE`
 
 | *required*
-| `True`
+| `False`
 
 | *cli_name*
-| `--auth-token-algorithm`
+| `--auth-group-definition-file`
 
 | *fallback*
 | `None`
@@ -737,33 +945,31 @@ Algorithm to use when signing tokens
 | `None`
 |===
 
-You can set auth.token.algorithm from the environment by setting the environment variable `BG_AUTH_TOKEN_ALGORITHM`
+You can set auth.group_definition_file from the environment by setting the environment variable `BG_AUTH_GROUP_DEFINITION_FILE`
 
-You can set `auth.token.algorithm` from the command-line by specifying `--auth-token-algorithm` at Beer Garden's entrypoint.
+You can set `auth.group_definition_file` from the command-line by specifying `--auth-group-definition-file` at Beer Garden's entrypoint.
 
-If `auth.token.algorithm` is not set in any of the sources listed, it will fallback to the default value `HS256`
+=== auth.role_definition_file
 
-=== auth.token.lifetime
-
-Time (seconds) before a token expires
+Path to the yaml file that defines roles used for authorization
 
 |===
 | Attribute | Value
 
 | *item_type*
-| `int`
+| `str`
 
 | *default*
-| `1200`
+| `None`
 
 | *env_name*
-| `BG_AUTH_TOKEN_LIFETIME`
+| `BG_AUTH_ROLE_DEFINITION_FILE`
 
 | *required*
-| `True`
+| `False`
 
 | *cli_name*
-| `--auth-token-lifetime`
+| `--auth-role-definition-file`
 
 | *fallback*
 | `None`
@@ -772,15 +978,13 @@ Time (seconds) before a token expires
 | `None`
 |===
 
-You can set auth.token.lifetime from the environment by setting the environment variable `BG_AUTH_TOKEN_LIFETIME`
+You can set auth.role_definition_file from the environment by setting the environment variable `BG_AUTH_ROLE_DEFINITION_FILE`
 
-You can set `auth.token.lifetime` from the command-line by specifying `--auth-token-lifetime` at Beer Garden's entrypoint.
+You can set `auth.role_definition_file` from the command-line by specifying `--auth-role-definition-file` at Beer Garden's entrypoint.
 
-If `auth.token.lifetime` is not set in any of the sources listed, it will fallback to the default value `1200`
+=== auth.token_secret
 
-=== auth.token.secret
-
-Secret to use when signing tokens
+Secret to use when signing authentication tokens
 
 |===
 | Attribute | Value
@@ -807,9 +1011,9 @@ Secret to use when signing tokens
 | `None`
 |===
 
-You can set auth.token.secret from the environment by setting the environment variable `BG_AUTH_TOKEN_SECRET`
+You can set auth.token_secret from the environment by setting the environment variable `BG_AUTH_TOKEN_SECRET`
 
-You can set `auth.token.secret` from the command-line by specifying `--auth-token-secret` at Beer Garden's entrypoint.
+You can set `auth.token_secret` from the command-line by specifying `--auth-token-secret` at Beer Garden's entrypoint.
 
 === configuration.file
 
@@ -1050,6 +1254,41 @@ You can set `db.ttl.action` from the command-line by specifying `--db-ttl-action
 
 If `db.ttl.action` is not set in any of the sources listed, it will fallback to the default value `-1`
 
+=== db.ttl.file
+
+Number of minutes to wait before deleting FILE documents (negative number for never)
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `int`
+
+| *default*
+| `15`
+
+| *env_name*
+| `BG_DB_TTL_FILE`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--db-ttl-file`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set db.ttl.file from the environment by setting the environment variable `BG_DB_TTL_FILE`
+
+You can set `db.ttl.file` from the command-line by specifying `--db-ttl-file` at Beer Garden's entrypoint.
+
+If `db.ttl.file` is not set in any of the sources listed, it will fallback to the default value `15`
+
 === db.ttl.info
 
 Number of minutes to wait before deleting INFO requests (negative number for never)
@@ -1189,41 +1428,6 @@ You can set entry.http.port from the environment by setting the environment vari
 You can set `entry.http.port` from the command-line by specifying `--entry-http-port` at Beer Garden's entrypoint.
 
 If `entry.http.port` is not set in any of the sources listed, it will fallback to the default value `2337`
-
-=== entry.http.public_fqdn
-
-Public fully-qualified domain name
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `str`
-
-| *default*
-| `localhost`
-
-| *env_name*
-| `BG_ENTRY_HTTP_PUBLIC_FQDN`
-
-| *required*
-| `True`
-
-| *cli_name*
-| `--entry-http-public-fqdn`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set entry.http.public_fqdn from the environment by setting the environment variable `BG_ENTRY_HTTP_PUBLIC_FQDN`
-
-You can set `entry.http.public_fqdn` from the command-line by specifying `--entry-http-public-fqdn` at Beer Garden's entrypoint.
-
-If `entry.http.public_fqdn` is not set in any of the sources listed, it will fallback to the default value `localhost`
 
 === entry.http.ssl.ca_cert
 
@@ -1459,6 +1663,404 @@ You can set entry.http.url_prefix from the environment by setting the environmen
 You can set `entry.http.url_prefix` from the command-line by specifying `--entry-http-url-prefix` at Beer Garden's entrypoint.
 
 If `entry.http.url_prefix` is not set in any of the sources listed, it will fallback to the default value `/`
+
+=== entry.stomp.enabled
+
+Connect to a Stomp Broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `False`
+
+| *env_name*
+| `BG_ENTRY_STOMP_ENABLED`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--entry-stomp-enabled`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.enabled from the environment by setting the environment variable `BG_ENTRY_STOMP_ENABLED`
+
+You can set `entry.stomp.enabled` from the command-line by specifying `--entry-stomp-enabled` at Beer Garden's entrypoint.
+
+=== entry.stomp.headers
+
+Headers to be sent with messages. Follows standard YAML formatting for lists with two variables 'key' and 'value'
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `list`
+
+| *default*
+| `[]`
+
+| *env_name*
+| `None`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-headers`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set `entry.stomp.headers` from the command-line by specifying `--entry-stomp-headers` at Beer Garden's entrypoint.
+
+=== entry.stomp.host
+
+Broker hostname
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `localhost`
+
+| *env_name*
+| `BG_ENTRY_STOMP_HOST`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--entry-stomp-host`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.host from the environment by setting the environment variable `BG_ENTRY_STOMP_HOST`
+
+You can set `entry.stomp.host` from the command-line by specifying `--entry-stomp-host` at Beer Garden's entrypoint.
+
+If `entry.stomp.host` is not set in any of the sources listed, it will fallback to the default value `localhost`
+
+=== entry.stomp.password
+
+Password to use for authentication
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_ENTRY_STOMP_PASSWORD`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-password`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.password from the environment by setting the environment variable `BG_ENTRY_STOMP_PASSWORD`
+
+You can set `entry.stomp.password` from the command-line by specifying `--entry-stomp-password` at Beer Garden's entrypoint.
+
+=== entry.stomp.port
+
+Broker port
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `int`
+
+| *default*
+| `61613`
+
+| *env_name*
+| `BG_ENTRY_STOMP_PORT`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--entry-stomp-port`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.port from the environment by setting the environment variable `BG_ENTRY_STOMP_PORT`
+
+You can set `entry.stomp.port` from the command-line by specifying `--entry-stomp-port` at Beer Garden's entrypoint.
+
+If `entry.stomp.port` is not set in any of the sources listed, it will fallback to the default value `61613`
+
+=== entry.stomp.send_destination
+
+Topic where events are published
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_ENTRY_STOMP_SEND_DESTINATION`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-send-destination`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.send_destination from the environment by setting the environment variable `BG_ENTRY_STOMP_SEND_DESTINATION`
+
+You can set `entry.stomp.send_destination` from the command-line by specifying `--entry-stomp-send-destination` at Beer Garden's entrypoint.
+
+=== entry.stomp.ssl.ca_cert
+
+Path to certificate file containing the certificate of the authority that issued the message broker certificate
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_ENTRY_STOMP_SSL_CA_CERT`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-ssl-ca-cert`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.ssl.ca_cert from the environment by setting the environment variable `BG_ENTRY_STOMP_SSL_CA_CERT`
+
+You can set `entry.stomp.ssl.ca_cert` from the command-line by specifying `--entry-stomp-ssl-ca-cert` at Beer Garden's entrypoint.
+
+=== entry.stomp.ssl.client_cert
+
+Path to client public certificate to use when communicating with the message broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_ENTRY_STOMP_SSL_CLIENT_CERT`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-ssl-client-cert`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.ssl.client_cert from the environment by setting the environment variable `BG_ENTRY_STOMP_SSL_CLIENT_CERT`
+
+You can set `entry.stomp.ssl.client_cert` from the command-line by specifying `--entry-stomp-ssl-client-cert` at Beer Garden's entrypoint.
+
+=== entry.stomp.ssl.client_key
+
+Path to client private key to use when communicating with the message broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_ENTRY_STOMP_SSL_CLIENT_KEY`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-ssl-client-key`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.ssl.client_key from the environment by setting the environment variable `BG_ENTRY_STOMP_SSL_CLIENT_KEY`
+
+You can set `entry.stomp.ssl.client_key` from the command-line by specifying `--entry-stomp-ssl-client-key` at Beer Garden's entrypoint.
+
+=== entry.stomp.ssl.use_ssl
+
+Use SSL when connecting to the message broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `False`
+
+| *env_name*
+| `BG_ENTRY_STOMP_SSL_USE_SSL`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--entry-stomp-ssl-use-ssl`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.ssl.use_ssl from the environment by setting the environment variable `BG_ENTRY_STOMP_SSL_USE_SSL`
+
+You can set `entry.stomp.ssl.use_ssl` from the command-line by specifying `--entry-stomp-ssl-use-ssl` at Beer Garden's entrypoint.
+
+=== entry.stomp.subscribe_destination
+
+Topic to listen for operations
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_ENTRY_STOMP_SUBSCRIBE_DESTINATION`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-subscribe-destination`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.subscribe_destination from the environment by setting the environment variable `BG_ENTRY_STOMP_SUBSCRIBE_DESTINATION`
+
+You can set `entry.stomp.subscribe_destination` from the command-line by specifying `--entry-stomp-subscribe-destination` at Beer Garden's entrypoint.
+
+=== entry.stomp.username
+
+Username to use for authentication
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_ENTRY_STOMP_USERNAME`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--entry-stomp-username`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set entry.stomp.username from the environment by setting the environment variable `BG_ENTRY_STOMP_USERNAME`
+
+You can set `entry.stomp.username` from the command-line by specifying `--entry-stomp-username` at Beer Garden's entrypoint.
 
 === garden.name
 
@@ -2389,7 +2991,7 @@ If `mq.heartbeat_interval` is not set in any of the sources listed, it will fall
 
 === mq.host
 
-Hostname of MQ to use
+Will be used by the Beergarden application as the location of the message broker.
 
 |===
 | Attribute | Value
@@ -2457,6 +3059,111 @@ You can set `mq.virtual_host` from the command-line by specifying `--mq-virtual-
 
 If `mq.virtual_host` is not set in any of the sources listed, it will fallback to the default value `/`
 
+=== parent.http.access_token
+
+Access token for authentication
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_HTTP_ACCESS_TOKEN`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-http-access-token`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.http.access_token from the environment by setting the environment variable `BG_PARENT_HTTP_ACCESS_TOKEN`
+
+You can set `parent.http.access_token` from the command-line by specifying `--parent-http-access-token` at Beer Garden's entrypoint.
+
+=== parent.http.api_version
+
+Beergarden API version
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `int`
+
+| *default*
+| `1`
+
+| *env_name*
+| `BG_PARENT_HTTP_API_VERSION`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--parent-http-api-version`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `[1]`
+|===
+
+You can set parent.http.api_version from the environment by setting the environment variable `BG_PARENT_HTTP_API_VERSION`
+
+You can set `parent.http.api_version` from the command-line by specifying `--parent-http-api-version` at Beer Garden's entrypoint.
+
+If `parent.http.api_version` is not set in any of the sources listed, it will fallback to the default value `1`
+
+=== parent.http.client_timeout
+
+Max time RestClient will wait for server response
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `float`
+
+| *default*
+| `-1`
+
+| *env_name*
+| `BG_PARENT_HTTP_CLIENT_TIMEOUT`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--parent-http-client-timeout`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.http.client_timeout from the environment by setting the environment variable `BG_PARENT_HTTP_CLIENT_TIMEOUT`
+
+You can set `parent.http.client_timeout` from the command-line by specifying `--parent-http-client-timeout` at Beer Garden's entrypoint.
+
+If `parent.http.client_timeout` is not set in any of the sources listed, it will fallback to the default value `-1`
+
+This setting controls how long the HTTP(s) client will wait when opening a connection to Beergarden before aborting. This prevents some strange Beergarden server state from causing plugins to hang indefinitely. Set to -1 to disable (this is a bad idea in production code, see the Requests documentation).
+
 === parent.http.enabled
 
 Publish events to parent garden over HTTP
@@ -2501,13 +3208,13 @@ Host for the HTTP Server to bind to
 | `str`
 
 | *default*
-| `0.0.0.0`
+| `None`
 
 | *env_name*
 | `BG_PARENT_HTTP_HOST`
 
 | *required*
-| `True`
+| `False`
 
 | *cli_name*
 | `--parent-http-host`
@@ -2523,7 +3230,38 @@ You can set parent.http.host from the environment by setting the environment var
 
 You can set `parent.http.host` from the command-line by specifying `--parent-http-host` at Beer Garden's entrypoint.
 
-If `parent.http.host` is not set in any of the sources listed, it will fallback to the default value `0.0.0.0`
+=== parent.http.password
+
+Password for authentication
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_HTTP_PASSWORD`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-http-password`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.http.password from the environment by setting the environment variable `BG_PARENT_HTTP_PASSWORD`
+
+You can set `parent.http.password` from the command-line by specifying `--parent-http-password` at Beer Garden's entrypoint.
 
 === parent.http.port
 
@@ -2560,9 +3298,9 @@ You can set `parent.http.port` from the command-line by specifying `--parent-htt
 
 If `parent.http.port` is not set in any of the sources listed, it will fallback to the default value `2337`
 
-=== parent.http.public_fqdn
+=== parent.http.refresh_token
 
-Public fully-qualified domain name
+Refresh token for authentication
 
 |===
 | Attribute | Value
@@ -2571,51 +3309,16 @@ Public fully-qualified domain name
 | `str`
 
 | *default*
-| `localhost`
+| `None`
 
 | *env_name*
-| `BG_PARENT_HTTP_PUBLIC_FQDN`
-
-| *required*
-| `True`
-
-| *cli_name*
-| `--parent-http-public-fqdn`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set parent.http.public_fqdn from the environment by setting the environment variable `BG_PARENT_HTTP_PUBLIC_FQDN`
-
-You can set `parent.http.public_fqdn` from the command-line by specifying `--parent-http-public-fqdn` at Beer Garden's entrypoint.
-
-If `parent.http.public_fqdn` is not set in any of the sources listed, it will fallback to the default value `localhost`
-
-=== parent.http.skip_events
-
-Events to be skipped
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `list`
-
-| *default*
-| `['DB_CREATE']`
-
-| *env_name*
-| `None`
+| `BG_PARENT_HTTP_REFRESH_TOKEN`
 
 | *required*
 | `False`
 
 | *cli_name*
-| `--parent-http-skip-events`
+| `--parent-http-refresh-token`
 
 | *fallback*
 | `None`
@@ -2624,9 +3327,9 @@ Events to be skipped
 | `None`
 |===
 
-You can set `parent.http.skip_events` from the command-line by specifying `--parent-http-skip-events` at Beer Garden's entrypoint.
+You can set parent.http.refresh_token from the environment by setting the environment variable `BG_PARENT_HTTP_REFRESH_TOKEN`
 
-If `parent.http.skip_events` is not set in any of the sources listed, it will fallback to the default value `['DB_CREATE']`
+You can set `parent.http.refresh_token` from the command-line by specifying `--parent-http-refresh-token` at Beer Garden's entrypoint.
 
 === parent.http.ssl.ca_cert
 
@@ -2661,77 +3364,110 @@ You can set parent.http.ssl.ca_cert from the environment by setting the environm
 
 You can set `parent.http.ssl.ca_cert` from the command-line by specifying `--parent-http-ssl-ca-cert` at Beer Garden's entrypoint.
 
-=== parent.http.ssl.ca_path
+=== parent.http.ssl.ca_verify
 
-Path to CA certificate path to use for SSLContext
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `str`
-
-| *default*
-| `None`
-
-| *env_name*
-| `BG_PARENT_HTTP_SSL_CA_PATH`
-
-| *required*
-| `False`
-
-| *cli_name*
-| `--parent-http-ssl-ca-path`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set parent.http.ssl.ca_path from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_CA_PATH`
-
-You can set `parent.http.ssl.ca_path` from the command-line by specifying `--parent-http-ssl-ca-path` at Beer Garden's entrypoint.
-
-=== parent.http.ssl.client_cert_verify
-
-Client certificate mode to use when handling requests
+Verify server certificate when using SSL
 
 |===
 | Attribute | Value
 
 | *item_type*
-| `str`
+| `bool`
 
 | *default*
-| `NONE`
+| `True`
 
 | *env_name*
-| `BG_PARENT_HTTP_SSL_CLIENT_CERT_VERIFY`
+| `BG_PARENT_HTTP_SSL_CA_VERIFY`
 
 | *required*
 | `True`
 
 | *cli_name*
-| `--parent-http-ssl-client-cert-verify`
+| `--parent-http-ssl-no-ca-verify`
 
 | *fallback*
 | `None`
 
 | *choices*
-| `['NONE', 'OPTIONAL', 'REQUIRED']`
+| `None`
 |===
 
-You can set parent.http.ssl.client_cert_verify from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_CLIENT_CERT_VERIFY`
+You can set parent.http.ssl.ca_verify from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_CA_VERIFY`
 
-You can set `parent.http.ssl.client_cert_verify` from the command-line by specifying `--parent-http-ssl-client-cert-verify` at Beer Garden's entrypoint.
+You can set `parent.http.ssl.ca_verify` from the command-line by specifying `--parent-http-ssl-no-ca-verify` at Beer Garden's entrypoint.
 
-If `parent.http.ssl.client_cert_verify` is not set in any of the sources listed, it will fallback to the default value `NONE`
+If `parent.http.ssl.ca_verify` is not set in any of the sources listed, it will fallback to the default value `True`
+
+=== parent.http.ssl.client_cert
+
+Client certificate to use
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_HTTP_SSL_CLIENT_CERT`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-http-ssl-client-cert`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.http.ssl.client_cert from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_CLIENT_CERT`
+
+You can set `parent.http.ssl.client_cert` from the command-line by specifying `--parent-http-ssl-client-cert` at Beer Garden's entrypoint.
+
+=== parent.http.ssl.client_key
+
+Client key to use
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_HTTP_SSL_CLIENT_KEY`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-http-ssl-client-key`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.http.ssl.client_key from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_CLIENT_KEY`
+
+You can set `parent.http.ssl.client_key` from the command-line by specifying `--parent-http-ssl-client-key` at Beer Garden's entrypoint.
 
 === parent.http.ssl.enabled
 
-Serve content using SSL
+Use SSL when connecting
 
 |===
 | Attribute | Value
@@ -2761,72 +3497,6 @@ Serve content using SSL
 You can set parent.http.ssl.enabled from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_ENABLED`
 
 You can set `parent.http.ssl.enabled` from the command-line by specifying `--parent-http-ssl-enabled` at Beer Garden's entrypoint.
-
-=== parent.http.ssl.private_key
-
-Path to a private key
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `str`
-
-| *default*
-| `None`
-
-| *env_name*
-| `BG_PARENT_HTTP_SSL_PRIVATE_KEY`
-
-| *required*
-| `False`
-
-| *cli_name*
-| `--parent-http-ssl-private-key`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set parent.http.ssl.private_key from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_PRIVATE_KEY`
-
-You can set `parent.http.ssl.private_key` from the command-line by specifying `--parent-http-ssl-private-key` at Beer Garden's entrypoint.
-
-=== parent.http.ssl.public_key
-
-Path to a public key
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `str`
-
-| *default*
-| `None`
-
-| *env_name*
-| `BG_PARENT_HTTP_SSL_PUBLIC_KEY`
-
-| *required*
-| `False`
-
-| *cli_name*
-| `--parent-http-ssl-public-key`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set parent.http.ssl.public_key from the environment by setting the environment variable `BG_PARENT_HTTP_SSL_PUBLIC_KEY`
-
-You can set `parent.http.ssl.public_key` from the command-line by specifying `--parent-http-ssl-public-key` at Beer Garden's entrypoint.
 
 === parent.http.url_prefix
 
@@ -2862,6 +3532,503 @@ You can set parent.http.url_prefix from the environment by setting the environme
 You can set `parent.http.url_prefix` from the command-line by specifying `--parent-http-url-prefix` at Beer Garden's entrypoint.
 
 If `parent.http.url_prefix` is not set in any of the sources listed, it will fallback to the default value `/`
+
+=== parent.http.username
+
+Username for authentication
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_HTTP_USERNAME`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-http-username`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.http.username from the environment by setting the environment variable `BG_PARENT_HTTP_USERNAME`
+
+You can set `parent.http.username` from the command-line by specifying `--parent-http-username` at Beer Garden's entrypoint.
+
+=== parent.skip_events
+
+Events to be skipped
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `list`
+
+| *default*
+| `[]`
+
+| *env_name*
+| `None`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-skip-events`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set `parent.skip_events` from the command-line by specifying `--parent-skip-events` at Beer Garden's entrypoint.
+
+=== parent.stomp.enabled
+
+Publish events to parent garden over STOMP
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `False`
+
+| *env_name*
+| `BG_PARENT_STOMP_ENABLED`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--parent-stomp-enabled`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.enabled from the environment by setting the environment variable `BG_PARENT_STOMP_ENABLED`
+
+You can set `parent.stomp.enabled` from the command-line by specifying `--parent-stomp-enabled` at Beer Garden's entrypoint.
+
+=== parent.stomp.headers
+
+Headers to be sent with messages. Follows standard YAML formatting for lists with two variables 'key' and 'value'
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `list`
+
+| *default*
+| `[]`
+
+| *env_name*
+| `None`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-headers`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set `parent.stomp.headers` from the command-line by specifying `--parent-stomp-headers` at Beer Garden's entrypoint.
+
+=== parent.stomp.host
+
+Broker hostname
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `localhost`
+
+| *env_name*
+| `BG_PARENT_STOMP_HOST`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--parent-stomp-host`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.host from the environment by setting the environment variable `BG_PARENT_STOMP_HOST`
+
+You can set `parent.stomp.host` from the command-line by specifying `--parent-stomp-host` at Beer Garden's entrypoint.
+
+If `parent.stomp.host` is not set in any of the sources listed, it will fallback to the default value `localhost`
+
+=== parent.stomp.password
+
+Password to use for authentication
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_STOMP_PASSWORD`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-password`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.password from the environment by setting the environment variable `BG_PARENT_STOMP_PASSWORD`
+
+You can set `parent.stomp.password` from the command-line by specifying `--parent-stomp-password` at Beer Garden's entrypoint.
+
+=== parent.stomp.port
+
+Broker port
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `int`
+
+| *default*
+| `61613`
+
+| *env_name*
+| `BG_PARENT_STOMP_PORT`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--parent-stomp-port`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.port from the environment by setting the environment variable `BG_PARENT_STOMP_PORT`
+
+You can set `parent.stomp.port` from the command-line by specifying `--parent-stomp-port` at Beer Garden's entrypoint.
+
+If `parent.stomp.port` is not set in any of the sources listed, it will fallback to the default value `61613`
+
+=== parent.stomp.send_destination
+
+Topic where events are published
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_STOMP_SEND_DESTINATION`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-send-destination`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.send_destination from the environment by setting the environment variable `BG_PARENT_STOMP_SEND_DESTINATION`
+
+You can set `parent.stomp.send_destination` from the command-line by specifying `--parent-stomp-send-destination` at Beer Garden's entrypoint.
+
+=== parent.stomp.ssl.ca_cert
+
+Path to certificate file containing the certificate of the authority that issued the message broker certificate
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_STOMP_SSL_CA_CERT`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-ssl-ca-cert`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.ssl.ca_cert from the environment by setting the environment variable `BG_PARENT_STOMP_SSL_CA_CERT`
+
+You can set `parent.stomp.ssl.ca_cert` from the command-line by specifying `--parent-stomp-ssl-ca-cert` at Beer Garden's entrypoint.
+
+=== parent.stomp.ssl.client_cert
+
+Path to client public certificate to use when communicating with the message broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_STOMP_SSL_CLIENT_CERT`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-ssl-client-cert`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.ssl.client_cert from the environment by setting the environment variable `BG_PARENT_STOMP_SSL_CLIENT_CERT`
+
+You can set `parent.stomp.ssl.client_cert` from the command-line by specifying `--parent-stomp-ssl-client-cert` at Beer Garden's entrypoint.
+
+=== parent.stomp.ssl.client_key
+
+Path to client private key to use when communicating with the message broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_STOMP_SSL_CLIENT_KEY`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-ssl-client-key`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.ssl.client_key from the environment by setting the environment variable `BG_PARENT_STOMP_SSL_CLIENT_KEY`
+
+You can set `parent.stomp.ssl.client_key` from the command-line by specifying `--parent-stomp-ssl-client-key` at Beer Garden's entrypoint.
+
+=== parent.stomp.ssl.use_ssl
+
+Use SSL when connecting to message broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `False`
+
+| *env_name*
+| `BG_PARENT_STOMP_SSL_USE_SSL`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--parent-stomp-ssl-use-ssl`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.ssl.use_ssl from the environment by setting the environment variable `BG_PARENT_STOMP_SSL_USE_SSL`
+
+You can set `parent.stomp.ssl.use_ssl` from the command-line by specifying `--parent-stomp-ssl-use-ssl` at Beer Garden's entrypoint.
+
+=== parent.stomp.subscribe_destination
+
+Topic to listen for operations
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_STOMP_SUBSCRIBE_DESTINATION`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-subscribe-destination`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.subscribe_destination from the environment by setting the environment variable `BG_PARENT_STOMP_SUBSCRIBE_DESTINATION`
+
+You can set `parent.stomp.subscribe_destination` from the command-line by specifying `--parent-stomp-subscribe-destination` at Beer Garden's entrypoint.
+
+=== parent.stomp.username
+
+Username to use for authentication
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `None`
+
+| *env_name*
+| `BG_PARENT_STOMP_USERNAME`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--parent-stomp-username`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set parent.stomp.username from the environment by setting the environment variable `BG_PARENT_STOMP_USERNAME`
+
+You can set `parent.stomp.username` from the command-line by specifying `--parent-stomp-username` at Beer Garden's entrypoint.
+
+=== plugin.allow_command_updates
+
+Allow commands of non-dev systems to be updated
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `False`
+
+| *env_name*
+| `BG_PLUGIN_ALLOW_COMMAND_UPDATES`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--plugin-allow-command-updates`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set plugin.allow_command_updates from the environment by setting the environment variable `BG_PLUGIN_ALLOW_COMMAND_UPDATES`
+
+You can set `plugin.allow_command_updates` from the command-line by specifying `--plugin-allow-command-updates` at Beer Garden's entrypoint.
+
+When False, this prevents changes to the command definitions of a registered version of a system. This means that the system will fail to start if the commands do not match what is on record for that version of the system. When True, the system will be allowed to start and the commands on record will be updated accordingly. NOTE: System versions containing 'dev' are exempt from this check.
 
 === plugin.local.auth.password
 
@@ -2993,27 +4160,27 @@ Host environment variables that will be propagated to local plugin processes
 
 You can set `plugin.local.host_env_vars` from the command-line by specifying `--plugin-local-host-env-vars` at Beer Garden's entrypoint.
 
-=== plugin.local.logging.stream_files
+=== plugin.local.logging.config_file
 
-Write plugin STDOUT to plugin.out and plugin STDERR to plugin.err
+Path to a logging configuration file for local plugins
 
 |===
 | Attribute | Value
 
 | *item_type*
-| `bool`
+| `str`
 
 | *default*
-| `False`
+| `None`
 
 | *env_name*
-| `BG_PLUGIN_LOCAL_LOGGING_STREAM_FILES`
+| `BG_PLUGIN_LOCAL_LOGGING_CONFIG_FILE`
 
 | *required*
-| `True`
+| `False`
 
 | *cli_name*
-| `--plugin-local-logging-stream-files`
+| `--plugin-local-logging-config-file`
 
 | *fallback*
 | `None`
@@ -3022,9 +4189,44 @@ Write plugin STDOUT to plugin.out and plugin STDERR to plugin.err
 | `None`
 |===
 
-You can set plugin.local.logging.stream_files from the environment by setting the environment variable `BG_PLUGIN_LOCAL_LOGGING_STREAM_FILES`
+You can set plugin.local.logging.config_file from the environment by setting the environment variable `BG_PLUGIN_LOCAL_LOGGING_CONFIG_FILE`
 
-You can set `plugin.local.logging.stream_files` from the command-line by specifying `--plugin-local-logging-stream-files` at Beer Garden's entrypoint.
+You can set `plugin.local.logging.config_file` from the command-line by specifying `--plugin-local-logging-config-file` at Beer Garden's entrypoint.
+
+=== plugin.local.logging.fallback_level
+
+Level that will be used with a default logging configuration if config_file is not specified
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `INFO`
+
+| *env_name*
+| `BG_PLUGIN_LOCAL_LOGGING_FALLBACK_LEVEL`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--plugin-local-logging-fallback-level`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `['DEBUG', 'INFO', 'WARN', 'WARNING', 'ERROR', 'CRITICAL']`
+|===
+
+You can set plugin.local.logging.fallback_level from the environment by setting the environment variable `BG_PLUGIN_LOCAL_LOGGING_FALLBACK_LEVEL`
+
+You can set `plugin.local.logging.fallback_level` from the command-line by specifying `--plugin-local-logging-fallback-level` at Beer Garden's entrypoint.
+
+If `plugin.local.logging.fallback_level` is not set in any of the sources listed, it will fallback to the default value `INFO`
 
 === plugin.local.timeout.shutdown
 
@@ -3096,7 +4298,44 @@ You can set `plugin.local.timeout.startup` from the command-line by specifying `
 
 If `plugin.local.timeout.startup` is not set in any of the sources listed, it will fallback to the default value `5`
 
-=== plugin.logging.config_file
+=== plugin.mq.host
+
+Globally resolvable host name of message broker
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `localhost`
+
+| *env_name*
+| `BG_PLUGIN_MQ_HOST`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--plugin-mq-host`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set plugin.mq.host from the environment by setting the environment variable `BG_PLUGIN_MQ_HOST`
+
+You can set `plugin.mq.host` from the command-line by specifying `--plugin-mq-host` at Beer Garden's entrypoint.
+
+If `plugin.mq.host` is not set in any of the sources listed, it will fallback to the default value `localhost`
+
+This will be supplied to all plugins as the location of the message broker. In order to support both local and remote plugins it's important that this value be universally resolvable.
+
+=== plugin.remote.logging.config_file
 
 Path to a logging configuration file for plugins
 
@@ -3110,13 +4349,13 @@ Path to a logging configuration file for plugins
 | `None`
 
 | *env_name*
-| `BG_PLUGIN_LOGGING_CONFIG_FILE`
+| `BG_PLUGIN_REMOTE_LOGGING_CONFIG_FILE`
 
 | *required*
 | `False`
 
 | *cli_name*
-| `--plugin-logging-config-file`
+| `--plugin-remote-logging-config-file`
 
 | *fallback*
 | `None`
@@ -3125,11 +4364,11 @@ Path to a logging configuration file for plugins
 | `None`
 |===
 
-You can set plugin.logging.config_file from the environment by setting the environment variable `BG_PLUGIN_LOGGING_CONFIG_FILE`
+You can set plugin.remote.logging.config_file from the environment by setting the environment variable `BG_PLUGIN_REMOTE_LOGGING_CONFIG_FILE`
 
-You can set `plugin.logging.config_file` from the command-line by specifying `--plugin-logging-config-file` at Beer Garden's entrypoint.
+You can set `plugin.remote.logging.config_file` from the command-line by specifying `--plugin-remote-logging-config-file` at Beer Garden's entrypoint.
 
-=== plugin.logging.fallback_level
+=== plugin.remote.logging.fallback_level
 
 Level that will be used with a default logging configuration if config_file is not specified
 
@@ -3143,13 +4382,13 @@ Level that will be used with a default logging configuration if config_file is n
 | `INFO`
 
 | *env_name*
-| `BG_PLUGIN_LOGGING_FALLBACK_LEVEL`
+| `BG_PLUGIN_REMOTE_LOGGING_FALLBACK_LEVEL`
 
 | *required*
 | `True`
 
 | *cli_name*
-| `--plugin-logging-fallback-level`
+| `--plugin-remote-logging-fallback-level`
 
 | *fallback*
 | `None`
@@ -3158,11 +4397,11 @@ Level that will be used with a default logging configuration if config_file is n
 | `['DEBUG', 'INFO', 'WARN', 'WARNING', 'ERROR', 'CRITICAL']`
 |===
 
-You can set plugin.logging.fallback_level from the environment by setting the environment variable `BG_PLUGIN_LOGGING_FALLBACK_LEVEL`
+You can set plugin.remote.logging.fallback_level from the environment by setting the environment variable `BG_PLUGIN_REMOTE_LOGGING_FALLBACK_LEVEL`
 
-You can set `plugin.logging.fallback_level` from the command-line by specifying `--plugin-logging-fallback-level` at Beer Garden's entrypoint.
+You can set `plugin.remote.logging.fallback_level` from the command-line by specifying `--plugin-remote-logging-fallback-level` at Beer Garden's entrypoint.
 
-If `plugin.logging.fallback_level` is not set in any of the sources listed, it will fallback to the default value `INFO`
+If `plugin.remote.logging.fallback_level` is not set in any of the sources listed, it will fallback to the default value `INFO`
 
 === plugin.status_heartbeat
 
@@ -3234,9 +4473,44 @@ You can set `plugin.status_timeout` from the command-line by specifying `--plugi
 
 If `plugin.status_timeout` is not set in any of the sources listed, it will fallback to the default value `30`
 
-=== publish_hostname
+=== request_validation.dynamic_choices.command.timeout
 
-Publicly accessible hostname for plugins to connect to
+Time to wait for a command-based choices validation
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `int`
+
+| *default*
+| `10`
+
+| *env_name*
+| `BG_REQUEST_VALIDATION_DYNAMIC_CHOICES_COMMAND_TIMEOUT`
+
+| *required*
+| `False`
+
+| *cli_name*
+| `--request_validation-dynamic_choices-command-timeout`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set request_validation.dynamic_choices.command.timeout from the environment by setting the environment variable `BG_REQUEST_VALIDATION_DYNAMIC_CHOICES_COMMAND_TIMEOUT`
+
+You can set `request_validation.dynamic_choices.command.timeout` from the command-line by specifying `--request_validation-dynamic_choices-command-timeout` at Beer Garden's entrypoint.
+
+If `request_validation.dynamic_choices.command.timeout` is not set in any of the sources listed, it will fallback to the default value `10`
+
+=== request_validation.dynamic_choices.url.ca_cert
+
+CA file for validating url-based choices
 
 |===
 | Attribute | Value
@@ -3245,51 +4519,49 @@ Publicly accessible hostname for plugins to connect to
 | `str`
 
 | *default*
-| `localhost`
+| `None`
 
 | *env_name*
-| `BG_PUBLISH_HOSTNAME`
+| `BG_REQUEST_VALIDATION_DYNAMIC_CHOICES_URL_CA_CERT`
 
 | *required*
+| `False`
+
+| *cli_name*
+| `--request_validation-dynamic_choices-url-ca-cert`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set request_validation.dynamic_choices.url.ca_cert from the environment by setting the environment variable `BG_REQUEST_VALIDATION_DYNAMIC_CHOICES_URL_CA_CERT`
+
+You can set `request_validation.dynamic_choices.url.ca_cert` from the command-line by specifying `--request_validation-dynamic_choices-url-ca-cert` at Beer Garden's entrypoint.
+
+=== request_validation.dynamic_choices.url.ca_verify
+
+Verify external certificates for url-based choices
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
 | `True`
 
-| *cli_name*
-| `--publish-hostname`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set publish_hostname from the environment by setting the environment variable `BG_PUBLISH_HOSTNAME`
-
-You can set `publish_hostname` from the command-line by specifying `--publish-hostname` at Beer Garden's entrypoint.
-
-If `publish_hostname` is not set in any of the sources listed, it will fallback to the default value `localhost`
-
-=== scheduler.auth.password
-
-Password that scheduler will use for authentication (needs bg-admin role)
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `str`
-
-| *default*
-| `None`
-
 | *env_name*
-| `BG_SCHEDULER_AUTH_PASSWORD`
+| `BG_REQUEST_VALIDATION_DYNAMIC_CHOICES_URL_CA_VERIFY`
 
 | *required*
 | `False`
 
 | *cli_name*
-| `--scheduler-auth-password`
+| `--request_validation-dynamic_choices-url-no-ca-verify`
 
 | *fallback*
 | `None`
@@ -3298,42 +4570,11 @@ Password that scheduler will use for authentication (needs bg-admin role)
 | `None`
 |===
 
-You can set scheduler.auth.password from the environment by setting the environment variable `BG_SCHEDULER_AUTH_PASSWORD`
+You can set request_validation.dynamic_choices.url.ca_verify from the environment by setting the environment variable `BG_REQUEST_VALIDATION_DYNAMIC_CHOICES_URL_CA_VERIFY`
 
-You can set `scheduler.auth.password` from the command-line by specifying `--scheduler-auth-password` at Beer Garden's entrypoint.
+You can set `request_validation.dynamic_choices.url.ca_verify` from the command-line by specifying `--request_validation-dynamic_choices-url-no-ca-verify` at Beer Garden's entrypoint.
 
-=== scheduler.auth.username
-
-Username that scheduler will use for authentication (needs bg-admin role)
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `str`
-
-| *default*
-| `None`
-
-| *env_name*
-| `BG_SCHEDULER_AUTH_USERNAME`
-
-| *required*
-| `False`
-
-| *cli_name*
-| `--scheduler-auth-username`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set scheduler.auth.username from the environment by setting the environment variable `BG_SCHEDULER_AUTH_USERNAME`
-
-You can set `scheduler.auth.username` from the command-line by specifying `--scheduler-auth-username` at Beer Garden's entrypoint.
+If `request_validation.dynamic_choices.url.ca_verify` is not set in any of the sources listed, it will fallback to the default value `True`
 
 === scheduler.job_defaults.coalesce
 
@@ -3440,77 +4681,9 @@ You can set `scheduler.max_workers` from the command-line by specifying `--sched
 
 If `scheduler.max_workers` is not set in any of the sources listed, it will fallback to the default value `10`
 
-=== validator.command.timeout
+=== ui.cors_enabled
 
-Time to wait for a command-based choices validation
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `int`
-
-| *default*
-| `10`
-
-| *env_name*
-| `BG_VALIDATOR_COMMAND_TIMEOUT`
-
-| *required*
-| `False`
-
-| *cli_name*
-| `--validator-command-timeout`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set validator.command.timeout from the environment by setting the environment variable `BG_VALIDATOR_COMMAND_TIMEOUT`
-
-You can set `validator.command.timeout` from the command-line by specifying `--validator-command-timeout` at Beer Garden's entrypoint.
-
-If `validator.command.timeout` is not set in any of the sources listed, it will fallback to the default value `10`
-
-=== validator.url.ca_cert
-
-CA file for validating url-based choices
-
-|===
-| Attribute | Value
-
-| *item_type*
-| `str`
-
-| *default*
-| `None`
-
-| *env_name*
-| `BG_VALIDATOR_URL_CA_CERT`
-
-| *required*
-| `False`
-
-| *cli_name*
-| `--validator-url-ca-cert`
-
-| *fallback*
-| `None`
-
-| *choices*
-| `None`
-|===
-
-You can set validator.url.ca_cert from the environment by setting the environment variable `BG_VALIDATOR_URL_CA_CERT`
-
-You can set `validator.url.ca_cert` from the command-line by specifying `--validator-url-ca-cert` at Beer Garden's entrypoint.
-
-=== validator.url.ca_verify
-
-Verify external certificates for url-based choices
+Determine if CORS should be enabled
 
 |===
 | Attribute | Value
@@ -3519,16 +4692,16 @@ Verify external certificates for url-based choices
 | `bool`
 
 | *default*
-| `True`
-
-| *env_name*
-| `BG_VALIDATOR_URL_CA_VERIFY`
-
-| *required*
 | `False`
 
+| *env_name*
+| `BG_UI_CORS_ENABLED`
+
+| *required*
+| `True`
+
 | *cli_name*
-| `--validator-url-no-ca-verify`
+| `--ui-cors-enabled`
 
 | *fallback*
 | `None`
@@ -3537,8 +4710,144 @@ Verify external certificates for url-based choices
 | `None`
 |===
 
-You can set validator.url.ca_verify from the environment by setting the environment variable `BG_VALIDATOR_URL_CA_VERIFY`
+You can set ui.cors_enabled from the environment by setting the environment variable `BG_UI_CORS_ENABLED`
 
-You can set `validator.url.ca_verify` from the command-line by specifying `--validator-url-no-ca-verify` at Beer Garden's entrypoint.
+You can set `ui.cors_enabled` from the command-line by specifying `--ui-cors-enabled` at Beer Garden's entrypoint.
 
-If `validator.url.ca_verify` is not set in any of the sources listed, it will fallback to the default value `True`
+=== ui.debug_mode
+
+Run the application in debug mode
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `False`
+
+| *env_name*
+| `BG_UI_DEBUG_MODE`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--ui-debug-mode`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set ui.debug_mode from the environment by setting the environment variable `BG_UI_DEBUG_MODE`
+
+You can set `ui.debug_mode` from the command-line by specifying `--ui-debug-mode` at Beer Garden's entrypoint.
+
+=== ui.execute_javascript
+
+Execute plugin-provided javascript
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `bool`
+
+| *default*
+| `False`
+
+| *env_name*
+| `BG_UI_EXECUTE_JAVASCRIPT`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--ui-execute-javascript`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set ui.execute_javascript from the environment by setting the environment variable `BG_UI_EXECUTE_JAVASCRIPT`
+
+You can set `ui.execute_javascript` from the command-line by specifying `--ui-execute-javascript` at Beer Garden's entrypoint.
+
+This is dangerous!! Setting this to true will instruct the browser to execute javascript provided by plugins. This means you MUST have control over all plugins running in the environment, otherwise this is a problem waiting to happen.
+
+=== ui.icon_default
+
+Default font-awesome icon to display
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `fa-beer`
+
+| *env_name*
+| `BG_UI_ICON_DEFAULT`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--ui-icon-default`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set ui.icon_default from the environment by setting the environment variable `BG_UI_ICON_DEFAULT`
+
+You can set `ui.icon_default` from the command-line by specifying `--ui-icon-default` at Beer Garden's entrypoint.
+
+If `ui.icon_default` is not set in any of the sources listed, it will fallback to the default value `fa-beer`
+
+=== ui.name
+
+The title to display on the GUI
+
+|===
+| Attribute | Value
+
+| *item_type*
+| `str`
+
+| *default*
+| `Beer Garden`
+
+| *env_name*
+| `BG_UI_NAME`
+
+| *required*
+| `True`
+
+| *cli_name*
+| `--ui-name`
+
+| *fallback*
+| `None`
+
+| *choices*
+| `None`
+|===
+
+You can set ui.name from the environment by setting the environment variable `BG_UI_NAME`
+
+You can set `ui.name` from the command-line by specifying `--ui-name` at Beer Garden's entrypoint.
+
+If `ui.name` is not set in any of the sources listed, it will fallback to the default value `Beer Garden`

--- a/docs/app/configuration.adoc
+++ b/docs/app/configuration.adoc
@@ -10,9 +10,9 @@ In this guide, we will go over the configuration options in Beer Garden and how 
 talk about the configuration at a high level, but we assume you have installed Beer Garden somehow.
 
 If you would like to jump straight to the definitions of `{bg-config}`, please redirect to
-link:/config_yaml.adoc[Config User Manual]
+link:../config_yaml/[Config User Manual]
 
-== Configuration Files ==
+== Configuration Files
 
 There are 3 configuration files that come installed with Beer Garden. If you installed an RPM, you will find these in
 `{rpm-config-home}`.
@@ -23,37 +23,25 @@ The default names are:
 * `{app-log-config}`
 * `{plugin-log-config}`
 
-////
-== Logging Configuration ==
-
-The logging configuration uses the standard python logging information. This can be edited as you see fit. If nothing is specified, Beer Garden will fall back to some basic defaults. You can generate a logging file through:
-
-[source,subs="attributes"]
-----
-generate_bartender_log_config -l {bt-log-config}
-generate_brew_view_log_config -l {bv-log-config}
-----
-////
-
-== Beer Garden Configuration ==
+== Beer Garden Configuration
 
 If you do not have a `{bg-config}` file, then you can generate one via:
 
 [source,subs="attributes"]
 ----
-generate_bartender_config -c {bg-config}
+generate_config -c {bg-config}
 ----
 
 If you already have a `{bg-config}` file, then you can upgrade it to the latest version via:
 
 [source,subs="attributes"]
 ----
-migrate_bartender_config -c {bg-config}
+migrate_config -c {bg-config}
 ----
 
-To see all of the definitions of `{bg-config}`, please checkout our link:user_manual/config_yaml.adoc[Config User Manual]
+To see all of the definitions of `{bg-config}`, please checkout our link:../config_yaml/[Config User Manual]
 
-== Beer Garden Logging Configuration ==
+== Beer Garden Logging Configuration
 
 As of Beer Garden 3.0.0, there is a new configuration file for plugin logging configurations. If this file is not
 included, a logging configuration is inferred from the logging configuration defined in {bg-config}.
@@ -77,7 +65,7 @@ The `handlers` section is a dictionary which may contain one of the following ke
 * `file`
 * `logstash`
 
-== Plugin Logging Configuration ==
+== Plugin Logging Configuration
 
 As of Beer Garden 3.0.0, there is a new configuration file for plugin logging configurations. If this file is not
 included, a logging configuration is inferred from the logging configuration defined in `{bg-config}`.

--- a/docs/app/parent-child.adoc
+++ b/docs/app/parent-child.adoc
@@ -1,5 +1,7 @@
-=== Connecting Gardens
+= Remote Gardens
 :page-layout: docs
+
+== Parent and Child Gardens
 
 Beer Garden has the ability to connect other Beer Gardens in a Parent-Child relationship. The approach Beer Garden takes
 for command and control is Parents can only send Operations to Children, and Children can only send Events to Parents.
@@ -12,7 +14,7 @@ execute against, not what systems are connected to itself and children. So if a 
 child tells the Parent it has the ability to route to all of the systems. The Parent will trust the Child Beer Garden to
 the routing appropriately.
 
-=== Internal Routing
+== Internal Routing
 
 The Router requires all objects to utilize the new standard Operation class.
 
@@ -25,13 +27,13 @@ Operations that can be forwarded include:
     GARDENS_SYNC
 
 
-==== How to determine where to route
+=== How to determine where to route
 
 Before any Operation is executed, Beer Garden has to determine if this is an Operation that it can fulfill. For all requests
 the Targeted Garden must be identified. If the Operation is not be forwarded, and is not for the local Beer Garden, then
 the Operation can not be routed. Each route-able Brewtils class has a different approach to determining the Target Beer Garden.
 
-==== Local Only Operations
+=== Local Only Operations
 
 There are a handful of Operations that will always be handled by the Local Beer Garden. The criteria utilized to determine
 this is:
@@ -42,13 +44,13 @@ this is:
 - Is the Operation kicking off Local Garden Actions?
 - Is the Operation managing local only resources?
 
-===== Systems and Instances
+==== Systems and Instances
 
 The combination of Namespace/System/Version is tied to a hosting Beer Garden. This information is stored within the Garden
 object. For System and Instance based Operations, this is a quick look up against the cached Garden information in the
 Router class.
 
-===== Requests
+==== Requests
 
 Operations to CREATE requests must first identify the Namespace/System/Version. Then that information is utilized to
 determine the Target Beer Garden, same as the Systems and Instances is looked up.

--- a/docs/app/security.adoc
+++ b/docs/app/security.adoc
@@ -1,0 +1,296 @@
+= Security
+:page-layout: docs
+:bg-github-uri: {git_group_uri}/beer-garden/tree/master/src/app
+
+== Authentication and Authorization
+
+Beer Garden supports some basic authentication and authorization features that
+allow you to create users and roles for the purposes of access control. This
+document will walk through how authentication and authorization work, as well as
+the various configuration options.
+
+These features are still in their infancy. As such, user fiendly methods of
+configuring the various options do not yet exist in many cases.
+
+== Authorization Basics
+
+Each API endpoint in Beer Garden is protected by a specific permission. A user
+attempting to access or modify data through an endpoint will first have to pass
+an access check, verifying that they have the required permission for the data
+that they are operating on. Details regarding the various permissions and how to
+assign them will be provided further on, but this is the basic principal on
+which the access control for Beer Garden operates. The Beer Garden UI works by
+making appropriate API calls behind the scenes. So too does the brewtils Plugin
+and EasyClient code. This means that access control for all aspects of Beer
+Garden is done through this permission checking that happens in the API.
+
+== Permissions
+
+Permissions are currently defined around typical CRUD operations for various
+entities. That is, for a given entity there is a "create", "read", "update", and
+"delete" permission. The current entities that exist are:
+
+* job
+* garden
+* queue
+* request
+* system
+* user
+
+Permissions are defined as strings of the format "<entity>:<operation>". For
+example: `garden:read`, `system:update`, `request:delete`.
+
+There are also a limited number of special permissions that do not map to a
+typical entity or operation. These currently include:
+
+* `event:forward` - This permission is required for garden-to-garden
+  communications. If your authorization is enabled on your remote gardens, this
+  permission must be assigned to the user account that your local garden uses to
+  communicate with those remote gardens. 
+
+CAUTION: Regular users should not have the `event:forward` permission, as it
+allows for the creation of requests against any garden or system.
+
+== Authentication Basics
+
+When authorization is enabled on your garden, users need a way to authenticate
+in order to access the garden using their account. From a user's perspective,
+this is done via the following:
+
+== Web UI Access
+
+When authorization is enabled, a "login" button will appear toward the top right
+of the page. Clicking this brings up a login box for the user to enter their
+credentials and sign in.
+
+== API Access
+
+For direct API access, a user would first send their credentials in a POST to
+`/api/v1/token`. This results in an access and refresh token being provided back
+in the response. The access token would then be provided by the user in
+subsequent API calls via the `Authorization: Bearer` header.
+
+This token retrieval and usage is handled for the user by the Web UI and
+EasyClient, but both use this API login and access token workflow behind the
+scenes.
+
+== Auth Settings
+
+Authorization and authentication settings are housed under a top level `auth`
+section of the main application configuration yaml file. Some general information
+about the settings is below, but for the full list of configuration options check
+out the link:../config_yaml/#auth-authentication_handlers-basic-enabled[configuration guide].
+
+=== Authentication Handlers
+
+This section allows you to configure the ways that users are able to
+authenticate to the garden. The available handlers are:
+
+* *basic* 
+* *trusted_header*
+
+Basic authentication allows users to login with a username and password.
+
+The trusted headers method allows for users to be authenticated via request
+headersthat get set via a trusted proxy. If your garden sits behind a proxy
+that will authenticate the user and place their username in a header,
+enabling this will tell the garden to use that provided username.
+
+When logging in via the UI, the login dialog will always show the input fields
+for username and password. If a user is authenticating by providing certificates
+on all requests that go through a proxy, these fields can safely be left blank.
+Since the trusted headers will be included on the login request, the user will
+still be able to login.
+
+NOTE: If you enable trusted headers authentication, it is imperative that users
+are required to access your garden through the proxy and do not have a means of
+accessing the garden directly. Direct garden access could allow users to set
+what are supposed to be trusted headers themselves. This would allow
+masquerading as whomever they wish.
+
+=== Default Admin Account
+
+A default admin user with the username "admin" and password "password" will be
+created when a garden is started for the first time. A superuser role will also
+be created and assigned to the admin user. The username and password for this
+account can be changed via the settings under `auth.default_admin`.
+
+=== Defining Roles
+
+Roles are simply groupings of permissions. Roles can contain whatever
+permissions you'd like, though it is generally advisable to construct your roles
+around the functionality that different types of users might need in order to
+perform their work on the garden.
+
+To define the roles that will be available in your garden, create a yaml file
+and set the `auth.role_definition_file` setting to the location of that file.
+The format of the file is simply a list of definitions containig a `name` and a
+list of `permissions`. Here are some excepts from the example `roles.yaml` file
+that you'll find in the link:{bg-github-uri}/example_configs[example configs.]
+
+[source,yaml]
+----
+- name: "job_manager"
+  permissions:
+    - "job:create"
+    - "job:read"
+    - "job:update"
+    - "job:delete"
+
+- name: "operator"
+  permissions:
+    - "garden:read"
+    - "request:create"
+    - "request:read"
+    - "system:read"
+
+- name: "read_only"
+  permissions:
+    - "job:read"
+    - "garden:read"
+    - "queue:read"
+    - "request:read"
+    - "system:read"
+----
+
+The available permissions are discussed in the earlier
+Permissions section.
+
+=== Assigning Roles
+
+Users are not granted permissions directly. Instead they are assigned roles in a
+specific domain, granting them all of the role's permissions in that domain.
+
+A domain is a set of gardens or systems (or the special "Global" domain scope,
+which provides universal access). When permissions get checked they follow a
+hierarchy, meaning access at the Global level confers access to all gardens and
+systems, access for a garden confers access for all systems in that garden, etc.
+
+Users can be assigned roles by logging into Beer Garden with an admin account
+and navigating to the Users section found in the Admin menu at the top right.
+This is also where you can create new users and reset a user's password.
+
+NOTE: Users will always have access to Requests that they have created, even
+without an explicit role assignment. This means that if a user creates a
+Request and then later the role granting them access to the Garden or System
+of the Request is revoked, the user will still have read access to that
+Request.
+
+=== Group Definition File
+
+When using the trusted header authentication handler, it is possible to have the
+groups listed in the configured `user_groups_header` mapped to Beer Garden role
+assignments. This is done via a group definition file, which looks like the
+following:
+
+[source,yaml]
+----
+- group: GLOBAL_SUPERUSER
+  role_assignments:
+    - role_name: superuser
+      domain:
+        scope: Global
+
+- group: DEFAULT_READ_ONLY
+  role_assignments:
+    - role_name: read_only
+      domain:
+        scope: Garden
+        identifiers:
+          name: default
+
+- group: DEFAULT_ECHO_JOB_MANAGER
+  role_assignments:
+    - role_name: job_manager
+      domain:
+        scope: System
+        identifiers:
+          name: echo
+          namespace: default
+    - role_name: read_only
+      domain:
+        scope: Garden
+        identifiers:
+          name: default
+----
+
+The example above shows how to define groups and the role assignments that will
+be mapped to them. The following is a brief description of each field.
+
+==== group
+
+The name of the assigned group that will be mapped. This is the name that will
+appear in the comma separated list of the header defined by
+`user_groups_header`.
+
+==== role_assignments
+
+A list of one or more role assignments to assign to users of the group. A role
+assignment is defined as:
+
+* *role_name:* The name of the role as defined in the role file that
+  `role_definition_file` points to.
+* *domain:* A domain is how we define the context in which the user has the
+  assigned roles. A domain consists of a scope and some identifiers.
+** *scope:* Can be one of _Global_ (universal access), _Garden_ (access
+   gardens matching the identifiers), or _System_ (access to systems matching
+   the identifiers).
+** *identifiers:* How to identify the items of the given scope that the user
+   should have access to. For _Global_, no identifiers are needed. _Garden_
+   requires a `name` identifier. _System_ requires at least a `name` and 
+   `namespace` and can optionally take a `version` as well. Providing fewer
+   identifiers results in a broader level of access being granted.
+
+=== Remote Gardens
+
+One very important note about authorization in Beer Garden is that it is only
+performed against the local garden. That is, the garden that the user is
+directly interacting with. If your garden has a remote garden connected to it,
+permissions for that remote garden should be assigned by a role assignment in an
+appropriate domain on the local garden.
+
+For instance, if you have a garden named "parent" and a remote garden connected
+to it named "child", you could have the following in your group definition file
+to assign access to the "child" garden:
+
+[source,yaml]
+----
+- group: CHILD_ECHO_OPERATOR
+  role_assignments:
+    - role_name: operator
+      domain:
+        scope: System
+        identifiers:
+          name: echo
+          namespace: child
+
+- group: CHILD_SUPERUSER
+  role_assignments:
+    - role_name: superuser
+      domain:
+        scope: Garden
+        identifiers:
+          name: child
+----
+
+It is important to note that no corresponding groups or users need to exist on
+the "child" garden. The remote garden effectively assumes that the local garden
+has already performed the necessary authorization checks and treats all
+forwarded operations as trusted.
+
+=== Syncing User Permissions
+
+It is possible to sync users, along with their permissions and password, from a
+local garden down to all known remote gardens. If your setup has remote gardens,
+a "Sync Users" button will present on the User Management page. This will allow
+you to initiate a sync that will make the user permission for remote garden
+match those of the local user.
+
+NOTE: The sync operation will overwrite any user on the remote garden with a
+username matching that of a user on the local garden. This means any roles
+that had been assigned on the remote garden will be removed, unless they had
+also been assigned on the local garden.
+
+The User Management page will list if a user is fully synced to all remote
+gardens. On the individual user page, a breakdown of which specific gardens
+are synced is available.

--- a/docs/app/upgrading.adoc
+++ b/docs/app/upgrading.adoc
@@ -1,4 +1,3 @@
-
 = Upgrading
 :page-layout: docs
 
@@ -6,10 +5,10 @@ Help with upgrading the Beer Garden application from 2.x to 3.x.
 
 == Should I Upgrade?
 
-It depends! In a nutshell, you should upgrade if you don't absolutely require functionality that was left on the cutting room floor during the jump to v3:
+For most users, the answer is yes. Beer Garden v2 is no longer supported and stopped receiving updates around the end of 2020. There are, however, changes in v3 that should be considered when making the upgrade decision. Specifically:
 
-- Users / Roles / Permissions. This functionality was very basic and will be completely rebuilt for version 3.1. As such, we decided that porting the current limited capability that existed in version 2 was not worth the effort.
-- Publishing events to a RabbitMQ topic. Again, this capability was fairly basic and will be getting an upgrade soon. If you depend on this capability it's best to hold off on upgrading. Also, be aware that the Event structure will most likely be different once this feature is re-enabled.
+- Users / Roles / Permissions. This has been completely rebuilt for v3 in a way that is fundamentally not compatible with what existed in v2. If you were using these features, be aware that you will need to recreate all users and roles. See the section on link:../security/[security] for more information.
+- Publishing events to a RabbitMQ topic. This capability was fairly basic, but was not carried over to v3. If you depend on this capability you would need to come up with an alternative solution in order to move to v3.
 
 == What's different?
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -44,6 +44,9 @@ link:app/parent-child[Parent & Child Configurations]::
 link:app/configuration[Configuration Guide]::
   Help with Application configuration
 
+link:app/security[Security Guide]::
+  Help with Authentication and Authorization
+
 link:app/api-users-guide/[API Guide]::
     If you aren't writing plugins, but rather using them, this guide is for you
 

--- a/docs/plugins/custom-display.adoc
+++ b/docs/plugins/custom-display.adoc
@@ -1,7 +1,11 @@
+= Customizing Command Forms
+:page-layout: docs
+
+NOTE: The features described on this page are considered deprecated and will be removed in the relatively near future.
 
 One of the benefits of Beer Garden is the web form that's automatically created for each Command. We try hard to make sure every combination of parameters will result in a form that makes sense and to give Plugin developers the tools they need to express their data. However, there may be a bug in a specific corner case, or you may want to change the form directly to fit your application. The following sections can help in those cases.
 
-==== Schema and/or Form Modification
+== Schema and/or Form Modification
 
 The form is generated using a package called Angular Schema Form (ASF). A complete tutorial on ASF is outside the scope of this document, so if you're unfamiliar with how ASF works please consult their documentation. At a very high level: ASF takes a JSON Schema (data model) and Form (presentation and styling) and uses those to construct the form that's presented on the Command View page. Behind the scenes the current data state is stored in the Model, which is updated whenever the user makes changes. This Model is what's shown in the Preview pane.
 
@@ -64,7 +68,7 @@ NOTE: Changing the Schema or Form does not change the data constraints of the Co
 
 NOTE: Don't forget to include *all* parameters in the `form` definition. The form definition can be an array as well as a dictionary.
 
-==== Command Page Replacement
+== Command Page Replacement
 Beer Garden also supports *completely* replacing the Command View page with custom HTML. This is intended to allow developers to implement functionality beyond what Angular Schema Form can provide.
 
 WARNING: This feature should be considered a Beta capability. If you're interested in using this feature in production please contact the Beer Garden team.

--- a/docs/plugins/local-vs-remote.adoc
+++ b/docs/plugins/local-vs-remote.adoc
@@ -30,7 +30,7 @@ Here is a quick breakdown:
 [TIP]
 .Pros of using remote plugins
 ====
-No real language restriction, only http(s) access to Beer Garden server required, you can provision the plugin with its own resources. No restrictions of how to start/configure your plugin
+Only http(s) access to Beer Garden server required, you can provision the plugin with its own resources. No restrictions of how to start/configure your plugin
 ====
 
 [CAUTION]
@@ -39,7 +39,7 @@ No real language restriction, only http(s) access to Beer Garden server required
 You are responsible for starting/monitoring/restarting your plugin. No way for Beer Garden to tell the plugin to reload it's configuration.
 ====
 
-Remote plugins refer to plugins that are not managed by Beer Garden itself. Remote plugins can exist on any machine that can make a http(s) connection to the Beer Garden web service. From a technical perspective, there are no restrictions on what language a remote plugin can be written in.
+Remote plugins refer to plugins that are not managed by Beer Garden itself. Remote plugins can exist on any machine that can make a http(s) connection to the Beer Garden web service.
 
 This does mean that the plugin developer is responsible for keeping the plugin process up and running. If the process dies for whatever reason, Beer Garden will not know how to restart it.
 

--- a/docs/plugins/plugin-developer-guide.adoc
+++ b/docs/plugins/plugin-developer-guide.adoc
@@ -1,7 +1,6 @@
 = Plugin Developer Guides
 :page-layout: docs
-:uri-bg-plugins: {git_group_uri}/bartender/tree/master/plugins
-:uri-brewtils: {git_group_uri}/py-brewtils/tree/master
+:uri-bg-plugins: {git_group_uri}/example-plugins
 
 These guides provide gentle introductions to plugin development. They are intended for anyone who wants to reduce the effort required to produce code backed by a ReST Interface and GUI. The plugin could be used for anything from provisioning a VM to calling a web service to controlling network devices.
 
@@ -9,17 +8,13 @@ These guides provide gentle introductions to plugin development. They are intend
 
 * link:../python/local-guide/[Python Plugin (Local)]
 * link:../python/remote-guide/[Python Plugin (Remote)]
-// TODO: Add the Java guide once it is done
-// * link:java/remote-guide/[Java Plugin (Remote)]
 
-TIP: If you want to know what Beer Garden is all about, find the answer in link:../what-is-beergarden/[What is Beer Garden?] If you're looking for a concise survey of plugin developer options, checkout the link:../plugin-syntax-quick-reference/[Plugin Developer Syntax Guide]
+TIP: If you want to know what Beer Garden is all about, find the answer in link:/docs/startup/what-is-beergarden/[What is Beer Garden?] If you're looking for a concise survey of plugin developer options, checkout the link:../plugin-syntax-quick-reference/[Plugin Developer Syntax Guide]
 
 These guides will dive into some of the more specific ways you can develop plugins. If you don't want to read through all this documentation and would rather look at code, you can checkout the {uri-bg-plugins}[example plugins] for lots of small examples. These guides will cover:
 
 * The basic structure of a Beer Garden plugin
 * How to create your first Beer Garden plugin
 * How to run your plugin
-
-Pick your favorite currently supported language and let's get started!
 
 TIP: If you don't know the difference between remote and local plugins, please check the link:../local-vs-remote/[local vs remote plugins docs]

--- a/docs/plugins/python/_includes/external-logging.adoc
+++ b/docs/plugins/python/_includes/external-logging.adoc
@@ -20,4 +20,4 @@ if __name__ == "__main__":
     # Init your plugin as normal.
 ----
 
-This tells Beer Garden to setup a root logger based on what is returned from the endpoint at `api/v1/config/logging`. Checkout the link:../../configuration[configuration section] for more information on how to configure this. This is mostly useful for remote plugins.
+This tells Beer Garden to setup a root logger based on what is returned from the endpoint at `api/v1/config/logging`. Checkout the link:/docs/app/configuration[configuration section] for more information on how to configure this. This is mostly useful for remote plugins.

--- a/docs/plugins/python/_includes/prereqs.adoc
+++ b/docs/plugins/python/_includes/prereqs.adoc
@@ -1,3 +1,5 @@
+:uri-install-guides: /docs/startup/installation-guides/
+
 In order to build a plugin you'll need a functioning Python environment. Setting that up is outside the scope of this tutorial; we recommend https://github.com/pyenv/pyenv[pyenv]. You'll also need access to a functioning Beer Garden. Check out the link:{uri-install-guides}[installation instructions] for ways to stand up your own Beer Garden.
 
 The simplest way to get started is to use the utility package we've created to make plugin building as easy as possible. The package is called `brewtils` and lives on PyPI. You can find link:{brewtils_docs_uri}[Brewtils API Documentation here]. Add it to your environment like this:

--- a/docs/plugins/python/local-guide.adoc
+++ b/docs/plugins/python/local-guide.adoc
@@ -1,9 +1,6 @@
 = Python Plugin Guide (Local)
 :page-layout: docs
 :includedir: _includes
-:uri-install-guides: ../../installation-guides/
-
-// TODO Should we update this to include Namespace?
 
 The goal of this section is to help you write a local plugin from scratch. In order to write local plugins there are a few things that you need.
 
@@ -242,4 +239,4 @@ This will allow you to successfully load Fabric.
 include::{includedir}/descriptive-plugin.adoc[]
 
 == Customizing Command Form
-include::{includedir}/custom-display.adoc[]
+The ability to customize the command form is a deprecated feature that will be removed in the relatively near future. For now, the documentation regarding this feature is still available link:../../custom-display/[here].

--- a/docs/plugins/python/remote-guide.adoc
+++ b/docs/plugins/python/remote-guide.adoc
@@ -1,9 +1,6 @@
 = Python Plugin Guide (Remote)
 :page-layout: docs
 :includedir: _includes
-:uri-install-guides: ../../installation-guides/
-
-// TODO Should we update this to include Namespaces?
 
 The goal of this section is to help you write a remote plugin from scratch. In order to write remote plugins there are a few things that you need.
 
@@ -11,9 +8,9 @@ The goal of this section is to help you write a remote plugin from scratch. In o
 
 include::{includedir}/prereqs.adoc[]
 
-Now you're ready to start writing your plugin.
-
 NOTE: Don't forget, if you're writing a remote plugin, you'll need to be able to access the Beer Garden REST Service
+
+Now you're ready to start writing your plugin.
 
 == Hello World!
 This section will take you through setting up a simple Hello, World example.
@@ -69,7 +66,7 @@ include::{includedir}/exceptions.adoc[]
 include::{includedir}/descriptive-plugin.adoc[]
 
 == Customizing Command Form
-include::{includedir}/custom-display.adoc[]
+The ability to customize the command form is a deprecated feature that will be removed in the relatively near future. For now, the documentation regarding this feature is still available link:../../custom-display/[here].
 
 == External Logging
 include::{includedir}/external-logging.adoc[]

--- a/docs/startup/installation-guides/git.adoc
+++ b/docs/startup/installation-guides/git.adoc
@@ -103,7 +103,7 @@ background. Use Ctrl-C to kill them.
 cd beer-garden; bin/app.sh
 ----
 
-If you are utilizng NPM to server the website
+If you are utilizing NPM to serve the website
 
 [source]
 ----

--- a/docs/startup/installation-guides/python.adoc
+++ b/docs/startup/installation-guides/python.adoc
@@ -13,46 +13,6 @@ A Beer Garden Python installation requires a few things to work:
 
 Installing these is outside the scope of this documentation, so please refer to their installation instructions for
 detailed installation instructions/configuration.
-// TODO We need to add NPM UI installer
-== Installing Brew View
-
-We host `brew-view` on PyPi server. You can install it via:
-
-[source,subs="attributes"]
-----
-pip install brew-view
-----
-
-You can then start the application:
-
-[source]
-----
-brew-view
-----
-
-You should see a log message saying the application started up. You can now navigate to http://localhost:2337 and see the GUI.
-
-If you would like to configure the application differently, you can generate your own configuration:
-
-[source]
-----
-generate_brew_view_config -c config.json
-----
-
-This will place a config file in `config.json`. Feel free to edit this file however you would like. Read more about the brew-view configuration in the link:../../configuration[configuration section.] Then you can startup the application and point to that configuration.
-
-[source]
-----
-brew-view -c config.json
-----
-
-Everything that is in the config.json can be overriden from the command-line. See more information with:
-
-[source]
-----
-brew-view --help
-----
-
 
 == Installing Beer Garden ==
 
@@ -63,35 +23,33 @@ We host `beer-garden` on PyPi. You can install it via:
 pip install beer-garden
 ----
 
-You can then start the application:
+You can generate a configuration file by running:
 
 [source]
 ----
-beer-garden
+generate_config -c config.yaml
 ----
 
-That's it! Beer-Garden is up and running.
-
-If you would like to configure the application differently, you can generate your own configuration:
-
-// TODO: Update config generation comment
-[source]
-----
-generate_bartender_config -c config.json
-----
-
-This will place a config file in `config.json`. Feel free to edit this file however you would like. Read more about
-the bartender configuration in the link:../../configuration[configuration section.] Then you can startup the
-application and point to that configuration.
+This will place a config file in `config.yaml`. Feel free to edit this file however you would like. Most of the
+defaults are likely fine for now, though you will need to update connection information for your message broker
+and database. Read more about the beergarden configuration in the link:/docs/app/configuration[configuration section.]
+Then you can startup the application and point to that configuration.
 
 [source]
 ----
-beergarden -c config.json
+beergarden -c config.yaml
 ----
 
-Everything that is in the `config.json` can be overriden from the command-line. See more information with:
+Everything that is in the `config.yaml` can be overriden from the command-line. See more information with:
 
 [source]
 ----
-bartender --help
+beergarden --help
 ----
+
+== Installing the Beer Garden UI
+
+The Beer Garden UI is a separate javascript application that does not get installed with the python backend. To run the UI, it is recommended that you following the directions in one of the sections below:
+
+* link:../docker/[Docker / Docker Compose]
+* link:../git/[Development Setup]

--- a/docs/startup/installation-guides/rhel.adoc
+++ b/docs/startup/installation-guides/rhel.adoc
@@ -1,6 +1,5 @@
 = Fedora/CentOS/RHEL Installation
 :page-layout: docs
-:uri-config: ../configuration
 
 This guide will take you through step-by-step installation instructions for a CentOS box.
 
@@ -135,7 +134,7 @@ You'll have to download our latest RPM. Then install with yum:
 sudo yum install beer-garden
 ----
 
-All Beer Garden configuration files are located in `/opt/beer-garden/conf`. Feel free to adjust the configuration as necessary. For more information on configuration see link:../../configuration/[Configuring Beer Garden].
+All Beer Garden configuration files are located in `/opt/beer-garden/conf`. Feel free to adjust the configuration as necessary. For more information on configuration see link:/docs/app/configuration/[Configuring Beer Garden].
 
 Next we just need to start the service and make sure it's running by default:
 

--- a/docs/startup/what-is-beergarden.adoc
+++ b/docs/startup/what-is-beergarden.adoc
@@ -47,7 +47,7 @@ class Calculator: <1>
 
 Now when the end user wants to add 1 and 2, they'll issue a Request to Beer Garden. The most common way to do that is to use the web UI that Beer Garden creates for this command. There will be input fields for "x" and "y", and a big "Make Request" button. Clicking that will take the user to a page where they'll be shown the result of their Request.
 
-NOTE: There are other ways to create a Request. Check out link:/docs/api-users-guide/#requests[Requests] to learn more.
+NOTE: There are other ways to create a Request. Check out link:/docs/app/api-users-guide/#requests[Requests] to learn more.
 
 // tag::how-can-it-help[]
 == How can it help?


### PR DESCRIPTION
This PR aims to improve the documentation in the following ways:

* Fix a host of obvious inaccuracies that are the result of lingering references to beer-garden 2.x.
* Fix dead links wherever I could find them.
* Remove outdated guidance and references to future plans that no longer exist
* Added documentation regarding new authentication and authorization features
* Regenerated the yapconf generated page that lists all of the available configuration options

This PR specifically does not attempt to improve the documentation in places where it is generally accurate, even if what's there could use a bit of tuning (see the section on parent and child gardens).