### PR TITLE
Remove references to Gitter

### DIFF
--- a/404.adoc
+++ b/404.adoc
@@ -1,3 +1,1 @@
 :page-layout: notfound
-
-TIP: If you think this page should exist, let us know {chat_uri}[Gitter]

--- a/_config/site.yml
+++ b/_config/site.yml
@@ -26,7 +26,6 @@ asciidoctor:
         git_uri: https://github.com
         git_ssh_uri: git@github.com:beer-garden/beer-garden.git
         git_group_uri: https://github.com/beer-garden
-        chat_uri: https://gitter.im/beer-garden-io/Lobby
         issues_uri: https://github.com/beer-garden/beer-garden/issues
         brewtils_docs_uri: https://brewtils.readthedocs.io
         bg_utils_docs_uri: https://bg-utils.readthedocs.io

--- a/_layouts/base.html.slim
+++ b/_layouts/base.html.slim
@@ -39,8 +39,6 @@ body.antialiased
             li.divider
             li: a href="https://github.com/beer-garden/beer-garden" Code
             li.divider
-            li: a href="https://gitter.im/beer-garden-io/Lobby" Discuss
-            li.divider
             li: a href="#{site.base_url}/docs/" Docs
 
     main
@@ -62,15 +60,13 @@ body.antialiased
         .col-sm-3
           h5 Support
           ul
-            li: a href="https://gitter.im/beer-garden-io/Lobby" Gitter
+            li: a href="https://github.com/beer-garden/beer-garden/issues" GitHub
         .col-sm-3.info
           h5 Information
           p Composed in AsciiDoc. Styled by bootstrap. Baked with Awestruct.
     .social-networks
       a.github href="https://github.com/beer-garden/beer-garden"
         i.fa.fa-github
-      a.gitter href="https://gitter.im/beer-garden-io/Lobby"
-        i.fa.fa-gitter
     .footer-copyright
       p © Beer Garden Project 2022.
 

--- a/docs/app/security.adoc
+++ b/docs/app/security.adoc
@@ -102,7 +102,7 @@ on all requests that go through a proxy, these fields can safely be left blank.
 Since the trusted headers will be included on the login request, the user will
 still be able to login.
 
-NOTE: If you enable trusted headers authentication, it is imperative that users
+CAUTION: If you enable trusted headers authentication, it is imperative that users
 are required to access your garden through the proxy and do not have a means of
 accessing the garden directly. Direct garden access could allow users to set
 what are supposed to be trusted headers themselves. This would allow
@@ -112,8 +112,11 @@ masquerading as whomever they wish.
 
 A default admin user with the username "admin" and password "password" will be
 created when a garden is started for the first time. A superuser role will also
-be created and assigned to the admin user. The username and password for this
-account can be changed via the settings under `auth.default_admin`.
+be created and assigned to the admin user. The initial username and password for
+this account can be changed via the settings under `auth.default_admin`. After
+garden initialization, the password for this account can be changed in the same
+manner as any regular user account, via the "Change Password" option in the top
+right ☰ menu.
 
 === Defining Roles
 

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -3,8 +3,6 @@
 
 The starting point for all your Beer Garden needs!
 
-TIP: Can't find the information you need? Reach out to project members and users via {chat_uri}[Gitter]
-
 == Getting Started
 
 Discover Beer Garden and how it can help you.

--- a/index.adoc
+++ b/index.adoc
@@ -28,14 +28,12 @@ On the other hand, if you're still unsure of exactly what Beer Garden is and wha
 
 Finally, if you're looking for specific info, trying to figure out how to do something, or wondering if Beer Garden can do the neat thing you thought of the best place to look is the link:docs[User Manual].
 
-CAUTION: We're excited to announce Beer Garden v3 has been released! Check out the link:docs/app/upgrading[Application] and link:docs/plugins/upgrading[Plugin] upgrade guides if you'd like to learn more.
+TIP: We're excited to announce Beer Garden v3 has been released! Check out the link:docs/app/upgrading[Application] and link:docs/plugins/upgrading[Plugin] upgrade guides if you'd like to learn more.
+
 
 == Getting Help
 
-We want Beer Garden to make your life easier. If there's anything that's unclear or difficult (or broken!) we want to know about it! Here are the best ways to get in touch with us:
-
-* Talk to us in {chat_uri}[Gitter]
-* Submit an issue to the {issues_uri}[Issue Tracker]
+If you encounter issues or have suggestions on how to make Beer Garden even better, please feel free to submit an issue to the {issues_uri}[Issue Tracker].
 
 
 === Contributing

--- a/stylesheets/styles.scss
+++ b/stylesheets/styles.scss
@@ -180,10 +180,6 @@ h2.hero {
     .github:hover {
       color: #959595;
     }
-
-    .gitter:hover {
-      color: #ff69b4;
-    }
   }
 
 }


### PR DESCRIPTION
This PR removes all references to Gitter, which the team is no longer monitoring.